### PR TITLE
Add CodeCov YAML file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "external/.*"       # External components are not written by us; ignore
+  - "single_include/.*" # The individual headers are all tested in unit tests


### PR DESCRIPTION
The exclusions in the lcov don't seem to filter the files properly.  This explicitly tells CodeCov to ignore paths that shouldn't be tested through a YAML file.