### PR TITLE
Move string utils out of main class

### DIFF
--- a/single_include/helpme_standalone.h
+++ b/single_include/helpme_standalone.h
@@ -31,7 +31,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include <sstream>
 #include <tuple>
 #include <vector>
 
@@ -893,6 +892,81 @@ inline diagonalizerType<std::complex<double>> LapackWrapper<std::complex<double>
 
 }  // Namespace helpme
 #endif  // Header guard
+// original file: ../src/string_utils.h
+
+// BEGINLICENSE
+//
+// This file is part of helPME, which is distributed under the BSD 3-clause license,
+// as described in the LICENSE file in the top level directory of this project.
+//
+// Author: Andrew C. Simmonett
+//
+// ENDLICENSE
+#ifndef _HELPME_STRING_UTIL_H_
+#define _HELPME_STRING_UTIL_H_
+
+#include <complex>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace helpme {
+
+/*!
+ * \brief makes a string representation of a floating point number.
+ * \param width the width used to display the number.
+ * \param precision the precision used to display the number.
+ * \return the string representation of the floating point number.
+ */
+template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+std::string formatNumber(const T &number, int width, int precision) {
+    std::stringstream stream;
+    stream.setf(std::ios::fixed, std::ios::floatfield);
+    stream << std::setw(width) << std::setprecision(precision) << number;
+    return stream.str();
+}
+
+/*!
+ * \brief makes a string representation of a complex number.
+ * \param width the width used to display the real and the imaginary components.
+ * \param precision the precision used to display the real and the imaginary components.
+ * \return the string representation of the complex number.
+ */
+template <typename T, typename std::enable_if<!std::is_floating_point<T>::value, int>::type = 0>
+std::string formatNumber(const T &number, int width, int precision) {
+    std::stringstream stream;
+    stream.setf(std::ios::fixed, std::ios::floatfield);
+    stream << "(" << std::setw(width) << std::setprecision(precision) << number.real() << ", " << std::setw(width)
+           << std::setprecision(precision) << number.imag() << ")";
+    return stream.str();
+}
+
+/*!
+ * \brief makes a string representation of a multdimensional tensor, stored in a flat array.
+ * \param data pointer to the start of the array holding the tensor information.
+ * \param size the length of the array holding the tensor information.
+ * \param rowDim the dimension of the fastest running index.
+ * \param width the width of each individual floating point number.
+ * \param precision used to display each floating point number.
+ * \return the string representation of the tensor.
+ */
+template <typename T>
+std::string stringify(T *data, size_t size, size_t rowDim, int width = 14, int precision = 8) {
+    std::stringstream stream;
+    for (size_t ind = 0; ind < size; ++ind) {
+        stream << formatNumber(data[ind], precision, width);
+        if (ind % rowDim == rowDim - 1)
+            stream << std::endl;
+        else
+            stream << "  ";
+    }
+    return stream.str();
+}
+
+}  // Namespace helpme
+
+#endif  // Header guard
 // #include "memory.h"
 
 namespace helpme {
@@ -1305,7 +1379,7 @@ class Matrix {
             const Real* rowData = data_ + row * nCols_;
             std::cout.setf(std::ios::fixed, std::ios::floatfield);
             for (int col = 0; col < nCols_; ++col) {
-                os << std::setw(18) << std::setprecision(10) << rowData[col] << " ";
+                os << formatNumber(rowData[col], nCols_, nCols_) << " ";
             }
             os << std::endl;
         }
@@ -1782,6 +1856,7 @@ class BSpline {
 
 }  // Namespace helpme
 #endif  // Header guard
+// #include "string_utils.h"
 
 /*!
  * \file helpme.h
@@ -1954,47 +2029,6 @@ class PMEInstance {
         if (!rPower_)
             throw std::runtime_error(
                 "Either setup(...) or setup_parallel(...) must be called before computing anything.");
-    }
-
-    /*!
-     * \brief makes a string representation of a multdimensional tensor, stored in a vector.
-     * \param data the vector holding the tensor information.
-     * \param rowDim the dimension of the fastest running index.
-     * \return the string representation of the tensor.
-     */
-    template <typename T>
-    std::string stringify(helpme::vector<T> data, size_t rowDim) {
-        std::stringstream stream;
-        std::cout.setf(std::ios::fixed, std::ios::floatfield);
-        for (size_t ind = 0; ind < data.size(); ++ind) {
-            stream << std::setw(18) << std::setprecision(10) << data[ind];
-            if (ind % rowDim == rowDim - 1)
-                stream << std::endl;
-            else
-                stream << "  ";
-        }
-        return stream.str();
-    }
-
-    /*!
-     * \brief makes a string representation of a multdimensional tensor, stored in a vector.
-     * \param data the array holding the tensor information.
-     * \param size the length of the array holding the tensor information.
-     * \param rowDim the dimension of the fastest running index.
-     * \return the string representation of the tensor.
-     */
-    template <typename T>
-    std::string stringify(T *data, size_t size, size_t rowDim) {
-        std::stringstream stream;
-        std::cout.setf(std::ios::fixed, std::ios::floatfield);
-        for (size_t ind = 0; ind < size; ++ind) {
-            stream << std::setw(18) << std::setprecision(10) << data[ind];
-            if (ind % rowDim == rowDim - 1)
-                stream << std::endl;
-            else
-                stream << "  ";
-        }
-        return stream.str();
     }
 
     /*!

--- a/src/helpme.h
+++ b/src/helpme.h
@@ -22,7 +22,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include <sstream>
 #include <tuple>
 #include <vector>
 
@@ -38,6 +37,7 @@ typedef struct ompi_communicator_t *MPI_Comm;
 #endif
 #include "powers.h"
 #include "splines.h"
+#include "string_utils.h"
 
 /*!
  * \file helpme.h
@@ -210,47 +210,6 @@ class PMEInstance {
         if (!rPower_)
             throw std::runtime_error(
                 "Either setup(...) or setup_parallel(...) must be called before computing anything.");
-    }
-
-    /*!
-     * \brief makes a string representation of a multdimensional tensor, stored in a vector.
-     * \param data the vector holding the tensor information.
-     * \param rowDim the dimension of the fastest running index.
-     * \return the string representation of the tensor.
-     */
-    template <typename T>
-    std::string stringify(helpme::vector<T> data, size_t rowDim) {
-        std::stringstream stream;
-        std::cout.setf(std::ios::fixed, std::ios::floatfield);
-        for (size_t ind = 0; ind < data.size(); ++ind) {
-            stream << std::setw(18) << std::setprecision(10) << data[ind];
-            if (ind % rowDim == rowDim - 1)
-                stream << std::endl;
-            else
-                stream << "  ";
-        }
-        return stream.str();
-    }
-
-    /*!
-     * \brief makes a string representation of a multdimensional tensor, stored in a vector.
-     * \param data the array holding the tensor information.
-     * \param size the length of the array holding the tensor information.
-     * \param rowDim the dimension of the fastest running index.
-     * \return the string representation of the tensor.
-     */
-    template <typename T>
-    std::string stringify(T *data, size_t size, size_t rowDim) {
-        std::stringstream stream;
-        std::cout.setf(std::ios::fixed, std::ios::floatfield);
-        for (size_t ind = 0; ind < size; ++ind) {
-            stream << std::setw(18) << std::setprecision(10) << data[ind];
-            if (ind % rowDim == rowDim - 1)
-                stream << std::endl;
-            else
-                stream << "  ";
-        }
-        return stream.str();
     }
 
     /*!

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -19,6 +19,7 @@
 #include <tuple>
 
 #include "lapack_wrapper.h"
+#include "string_utils.h"
 #include "memory.h"
 
 namespace helpme {
@@ -431,7 +432,7 @@ class Matrix {
             const Real* rowData = data_ + row * nCols_;
             std::cout.setf(std::ios::fixed, std::ios::floatfield);
             for (int col = 0; col < nCols_; ++col) {
-                os << std::setw(18) << std::setprecision(10) << rowData[col] << " ";
+                os << formatNumber(rowData[col], nCols_, nCols_) << " ";
             }
             os << std::endl;
         }

--- a/src/string_utils.h
+++ b/src/string_utils.h
@@ -1,0 +1,73 @@
+// BEGINLICENSE
+//
+// This file is part of helPME, which is distributed under the BSD 3-clause license,
+// as described in the LICENSE file in the top level directory of this project.
+//
+// Author: Andrew C. Simmonett
+//
+// ENDLICENSE
+#ifndef _HELPME_STRING_UTIL_H_
+#define _HELPME_STRING_UTIL_H_
+
+#include <complex>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+namespace helpme {
+
+/*!
+ * \brief makes a string representation of a floating point number.
+ * \param width the width used to display the number.
+ * \param precision the precision used to display the number.
+ * \return the string representation of the floating point number.
+ */
+template <typename T, typename std::enable_if<std::is_floating_point<T>::value, int>::type = 0>
+std::string formatNumber(const T &number, int width, int precision) {
+    std::stringstream stream;
+    stream.setf(std::ios::fixed, std::ios::floatfield);
+    stream << std::setw(width) << std::setprecision(precision) << number;
+    return stream.str();
+}
+
+/*!
+ * \brief makes a string representation of a complex number.
+ * \param width the width used to display the real and the imaginary components.
+ * \param precision the precision used to display the real and the imaginary components.
+ * \return the string representation of the complex number.
+ */
+template <typename T, typename std::enable_if<!std::is_floating_point<T>::value, int>::type = 0>
+std::string formatNumber(const T &number, int width, int precision) {
+    std::stringstream stream;
+    stream.setf(std::ios::fixed, std::ios::floatfield);
+    stream << "(" << std::setw(width) << std::setprecision(precision) << number.real() << ", " << std::setw(width)
+           << std::setprecision(precision) << number.imag() << ")";
+    return stream.str();
+}
+
+/*!
+ * \brief makes a string representation of a multdimensional tensor, stored in a flat array.
+ * \param data pointer to the start of the array holding the tensor information.
+ * \param size the length of the array holding the tensor information.
+ * \param rowDim the dimension of the fastest running index.
+ * \param width the width of each individual floating point number.
+ * \param precision used to display each floating point number.
+ * \return the string representation of the tensor.
+ */
+template <typename T>
+std::string stringify(T *data, size_t size, size_t rowDim, int width = 14, int precision = 8) {
+    std::stringstream stream;
+    for (size_t ind = 0; ind < size; ++ind) {
+        stream << formatNumber(data[ind], precision, width);
+        if (ind % rowDim == rowDim - 1)
+            stream << std::endl;
+        else
+            stream << "  ";
+    }
+    return stream.str();
+}
+
+}  // Namespace helpme
+
+#endif  // Header guard

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -9,6 +9,7 @@ set( SOURCES_UNITTESTS_TESTS
     unittest-matrix.cpp
     unittest-powers.cpp
     unittest-splines.cpp
+    unittest-string.cpp
 )
 if(HAVE_MPI)
     set( SOURCES_UNITTESTS_PARALLEL_TESTS

--- a/test/unittests/unittest-string.cpp
+++ b/test/unittests/unittest-string.cpp
@@ -1,0 +1,32 @@
+// BEGINLICENSE
+//
+// This file is part of helPME, which is distributed under the BSD 3-clause license,
+// as described in the LICENSE file in the top level directory of this project.
+//
+// Author: Andrew C. Simmonett
+//
+// ENDLICENSE
+
+#include "catch.hpp"
+
+#include "string_utils.h"
+
+TEST_CASE("test the number formatting routines.") {
+    SECTION("complex numbers") {
+        REQUIRE(helpme::formatNumber(std::complex<double>(1.22222220123, 0.00000933131), 15, 8) ==
+                "(     1.22222220,      0.00000933)");
+        REQUIRE(helpme::formatNumber(std::complex<float>(1.22222220123, 0.00000933131), 15, 8) ==
+                "(     1.22222221,      0.00000933)");
+        REQUIRE(helpme::formatNumber(std::complex<double>(1.22222220123, 0.00000933131), 10, 4) ==
+                "(    1.2222,     0.0000)");
+        REQUIRE(helpme::formatNumber(std::complex<float>(1.22222220123, 0.00000933131), 10, 4) ==
+                "(    1.2222,     0.0000)");
+    }
+
+    SECTION("complex numbers") {
+        REQUIRE(helpme::formatNumber(1.22222220123, 15, 8) == "     1.22222220");
+        REQUIRE(helpme::formatNumber(1.22222220123f, 15, 8) == "     1.22222221");
+        REQUIRE(helpme::formatNumber(1.22222220123, 10, 4) == "    1.2222");
+        REQUIRE(helpme::formatNumber(1.22222220123f, 10, 4) == "    1.2222");
+    }
+}


### PR DESCRIPTION
Improves the formatting of complex numbers in the debugging helpers.  Also moves them out of the main class and adds unit tests to keep codecov happy.