### PR TITLE
Add influence function caching for NVT

### DIFF
--- a/single_include/helpme_standalone.h
+++ b/single_include/helpme_standalone.h
@@ -2118,7 +2118,6 @@ static int cartAddress(int lx, int ly, int lz) {
 // This is used to define function pointers in the constructor, and makes it easy to add new kernels.
 #define ENABLE_KERNEL_WITH_INVERSE_R_EXPONENT_OF(n)                  \
     case n:                                                          \
-        convolveEFxn_ = &convolveEImpl<n>;                           \
         convolveEVFxn_ = &convolveEVImpl<n>;                         \
         cacheInfluenceFunctionFxn_ = &cacheInfluenceFunctionImpl<n>; \
         slfEFxn_ = &slfEImpl<n>;                                     \
@@ -2205,10 +2204,6 @@ class PMEInstance {
     RealVec splineModA_, splineModB_, splineModC_;
     /// The cached influence function involved in the convolution.
     RealVec cachedInfluenceFunction_;
-    /// A function pointer to call the approprate function to implement convolution, templated to the rPower value.
-    std::function<Real(int, int, int, int, int, int, int, Real, Complex *, const RealMat &, Real, Real, const Real *,
-                       const Real *, const Real *, int)>
-        convolveEFxn_;
     /// A function pointer to call the approprate function to implement convolution with virial, templated to
     /// the rPower value.
     std::function<Real(int, int, int, int, int, int, int, Real, Complex *, const RealMat &, Real, Real, const Real *,
@@ -2675,92 +2670,9 @@ class PMEInstance {
     }
 
     /*!
-     * \brief convolveEImpl performs the reciprocal space convolution, returning the energy
-     * \tparam rPower the exponent of the (inverse) distance kernel (e.g. 1 for Coulomb, 6 for attractive dispersion).
-     * \param nx the grid dimension in the x direction.
-     * \param ny the grid dimension in the y direction.
-     * \param nz the grid dimension in the z direction.
-     * \param myNx the subset of the grid in the x direction to be handled by this node.
-     * \param myNy the subset of the grid in the y direction to be handled by this node.
-     * \param startX the starting grid point handled by this node in the X direction.
-     * \param startY the starting grid point handled by this node in the Y direction.
-     * \param scaleFactor a scale factor to be applied to all computed energies and derivatives thereof (e.g. the
-     *        1 / [4 pi epslion0] for Coulomb calculations).
-     * \param gridPtr the Fourier space grid, with ordering YXZ.
-     * \param boxInv the reciprocal lattice vectors.
-     * \param volume the volume of the unit cell.
-     * \param kappa the attenuation parameter in units inverse of those used to specify coordinates.
-     * \param xMods the Fourier space norms of the x B-Splines.
-     * \param yMods the Fourier space norms of the y B-Splines.
-     * \param zMods the Fourier space norms of the z B-Splines.
-     * \param nThreads the number of OpenMP threads to use.
-     * \return the reciprocal space energy.
-     */
-    template <int rPower>
-    static Real convolveEImpl(int nx, int ny, int nz, int myNx, int myNy, int startX, int startY, Real scaleFactor,
-                              Complex *gridPtr, const RealMat &boxInv, Real volume, Real kappa, const Real *xMods,
-                              const Real *yMods, const Real *zMods, int nThreads) {
-        Real energy = 0;
-
-        bool nodeZero = startX == 0 && startY == 0;
-        if (rPower > 3 && nodeZero) {
-            // Kernels with rPower>3 are absolutely convergent and should have the m=0 term present.
-            // To compute it we need sum_ij c(i)c(j), which can be obtained from the structure factor norm.
-            Real prefac = 2 * scaleFactor * M_PI * sqrtPi * pow(kappa, rPower - 3) /
-                          ((rPower - 3) * gammaComputer<Real, rPower>::value * volume);
-            energy += prefac * std::norm(gridPtr[0]);
-        }
-        // Ensure the m=0 term convolution product is zeroed for the backtransform; it's been accounted for above.
-        if (nodeZero) gridPtr[0] = Complex(0, 0);
-
-        std::vector<short> xMVals(myNx), yMVals(myNy), zMVals(nz);
-        // Iterators to conveniently map {X,Y,Z} grid location to m_{X,Y,Z} value, where -1/2 << m/dim < 1/2.
-        for (int kx = 0; kx < myNx; ++kx) xMVals[kx] = startX + (kx + startX >= (nx + 1) / 2 ? kx - nx : kx);
-        for (int ky = 0; ky < myNy; ++ky) yMVals[ky] = startY + (ky + startY >= (ny + 1) / 2 ? ky - ny : ky);
-        for (int kz = 0; kz < nz; ++kz) zMVals[kz] = kz >= (nz + 1) / 2 ? kz - nz : kz;
-
-        Real bPrefac = M_PI * M_PI / (kappa * kappa);
-        Real volPrefac = scaleFactor * pow(M_PI, rPower - 1) / (sqrtPi * gammaComputer<Real, rPower>::value * volume);
-        int halfNx = nx / 2 + 1;
-        size_t nxz = myNx * nz;
-        const Real *boxPtr = boxInv[0];
-        size_t nyxz = myNy * nxz;
-        // Exclude m=0 cell.
-        int start = (nodeZero ? 1 : 0);
-// Writing the three nested loops in one allows for better load balancing in parallel.
-#pragma omp parallel for reduction(+ : energy) num_threads(nThreads)
-        for (size_t yxz = start; yxz < nyxz; ++yxz) {
-            size_t xz = yxz % nxz;
-            short ky = yxz / nxz;
-            short kx = xz / nz;
-            short kz = xz % nz;
-            // We only loop over the first nx/2+1 x values; this
-            // accounts for the "missing" complex conjugate values.
-            Real permPrefac = kx + startX != 0 && kx + startX != halfNx - 1 ? 2 : 1;
-            Real mx = (Real)xMVals[kx];
-            Real my = (Real)yMVals[ky];
-            Real mz = (Real)zMVals[kz];
-            Real mVecX = boxPtr[0] * mx + boxPtr[1] * my + boxPtr[2] * mz;
-            Real mVecY = boxPtr[3] * mx + boxPtr[4] * my + boxPtr[5] * mz;
-            Real mVecZ = boxPtr[6] * mx + boxPtr[7] * my + boxPtr[8] * mz;
-            Real mNormSq = mVecX * mVecX + mVecY * mVecY + mVecZ * mVecZ;
-            Real mTerm = raiseNormToIntegerPower<Real, rPower - 3>::compute(mNormSq);
-            Real bSquared = bPrefac * mNormSq;
-            Real incompleteGammaTerm = incompleteGammaComputer<Real, 3 - rPower>::compute(bSquared);
-            Complex &gridVal = gridPtr[ky * nxz + kx * nz + kz];
-            Real structFacNorm = std::norm(gridVal);
-            Real influenceFunction =
-                volPrefac * incompleteGammaTerm * mTerm * yMods[ky + startY] * xMods[kx + startX] * zMods[kz];
-            gridVal *= influenceFunction;
-            energy += permPrefac * influenceFunction * structFacNorm;
-        }
-        energy /= 2;
-
-        return energy;
-    }
-
-    /*!
-     * \brief convolveEVImpl performs the reciprocal space convolution, returning the energy
+     * \brief convolveEVImpl performs the reciprocal space convolution, returning the energy.  We opt to not cache
+     *        this the same way as the non-virial version because it's safe to assume that if the virial is requested
+     *        the box is likely to change, which renders the cache useless.
      * \tparam rPower the exponent of the (inverse) distance kernel (e.g. 1 for Coulomb, 6 for attractive dispersion).
      * \param nx the grid dimension in the x direction.
      * \param ny the grid dimension in the y direction.

--- a/single_include/helpme_standalone.h
+++ b/single_include/helpme_standalone.h
@@ -1571,6 +1571,29 @@ struct gammaComputer {
     static constexpr Real value = gammaRecursion<Real, twoS, (twoS > 0)>::value;
 };
 
+/*!
+ * \brief Computes the Gamma function using recursion instead of template metaprogramming.
+ * \f$ \Gamma[s] = \int_0^\infty t^{s-1} e^{-t} \mathrm{d}t \f$
+ * In this code we only need half integral values for the \f$s\f$ argument, so the input
+ * argument \f$s\f$ will yield \f$\Gamma[\frac{s}{2}]\f$.
+ * \tparam Real the floating point type to use for arithmetic.
+ * \param twoS twice the s value required.
+ */
+template <typename Real>
+Real nonTemplateGammaComputer(int twoS) {
+    if (twoS == 1) {
+        return sqrtPi;
+    } else if (twoS == 2) {
+        return 1;
+    } else if (twoS <= 0 && twoS % 2 == 0) {
+        return std::numeric_limits<Real>::max();
+    } else if (twoS > 0) {
+        return nonTemplateGammaComputer<Real>(twoS - 2) * (0.5f * twoS - 1);
+    } else {
+        return nonTemplateGammaComputer<Real>(twoS + 2) / (0.5f * twoS);
+    }
+}
+
 }  // Namespace helpme
 #endif  // Header guard
 // original file: ../src/gridsize.h
@@ -2093,15 +2116,16 @@ static int cartAddress(int lx, int ly, int lz) {
 }
 
 // This is used to define function pointers in the constructor, and makes it easy to add new kernels.
-#define ENABLE_KERNEL_WITH_INVERSE_R_EXPONENT_OF(n) \
-    case n:                                         \
-        convolveEFxn_ = &convolveEImpl<n>;          \
-        convolveEVFxn_ = &convolveEVImpl<n>;        \
-        slfEFxn_ = &slfEImpl<n>;                    \
-        dirEFxn_ = &dirEImpl<n>;                    \
-        adjEFxn_ = &adjEImpl<n>;                    \
-        dirEFFxn_ = &dirEFImpl<n>;                  \
-        adjEFFxn_ = &adjEFImpl<n>;                  \
+#define ENABLE_KERNEL_WITH_INVERSE_R_EXPONENT_OF(n)                  \
+    case n:                                                          \
+        convolveEFxn_ = &convolveEImpl<n>;                           \
+        convolveEVFxn_ = &convolveEVImpl<n>;                         \
+        cacheInfluenceFunctionFxn_ = &cacheInfluenceFunctionImpl<n>; \
+        slfEFxn_ = &slfEImpl<n>;                                     \
+        dirEFxn_ = &dirEImpl<n>;                                     \
+        adjEFxn_ = &adjEImpl<n>;                                     \
+        dirEFFxn_ = &dirEFImpl<n>;                                   \
+        adjEFFxn_ = &adjEFImpl<n>;                                   \
         break;
 
 /*!
@@ -2136,6 +2160,17 @@ class PMEInstance {
     using RealMat = Matrix<Real>;
     using RealVec = helpme::vector<Real>;
 
+   public:
+    /*!
+     * \brief The different conventions for orienting a lattice constructed from input parameters.
+     */
+    enum class LatticeType : int { XAligned = 0, ShapeMatrix = 1 };
+
+    /*!
+     * \brief The different conventions for numbering nodes.
+     */
+    enum class NodeOrder : int { ZYX = 0 };
+
    protected:
     /// The FFT grid dimensions in the {A,B,C} grid dimensions.
     int dimA_, dimB_, dimC_;
@@ -2168,6 +2203,8 @@ class PMEInstance {
     GridIterator gridIteratorA_, gridIteratorB_, gridIteratorC_;
     /// The (inverse) bspline moduli to normalize the spreading / probing steps; these are folded into the convolution.
     RealVec splineModA_, splineModB_, splineModC_;
+    /// The cached influence function involved in the convolution.
+    RealVec cachedInfluenceFunction_;
     /// A function pointer to call the approprate function to implement convolution, templated to the rPower value.
     std::function<Real(int, int, int, int, int, int, int, Real, Complex *, const RealMat &, Real, Real, const Real *,
                        const Real *, const Real *, int)>
@@ -2177,6 +2214,11 @@ class PMEInstance {
     std::function<Real(int, int, int, int, int, int, int, Real, Complex *, const RealMat &, Real, Real, const Real *,
                        const Real *, const Real *, RealMat &, int)>
         convolveEVFxn_;
+    /// A function pointer to call the approprate function to implement cacheing of the influence function that appears
+    //  in the convolution, templated to the rPower value.
+    std::function<void(int, int, int, int, int, int, int, Real, RealVec &, const RealMat &, Real, Real, const Real *,
+                       const Real *, const Real *, int)>
+        cacheInfluenceFunctionFxn_;
     /// A function pointer to call the approprate function to compute self energy, templated to the rPower value.
     std::function<Real(int, const RealMat &, Real, Real)> slfEFxn_;
     /// A function pointer to call the approprate function to compute the direct energy, templated to the rPower value.
@@ -2210,6 +2252,14 @@ class PMEInstance {
     int subsetOfCAlongA_, subsetOfCAlongB_, subsetOfBAlongC_;
     /// The size of a cache line, in units of the size of the Real type, to allow better memory allocation policies.
     Real cacheLineSizeInReals_;
+    /// The current unit cell parameters.
+    Real cellA_, cellB_, cellC_, cellAlpha_, cellBeta_, cellGamma_;
+    /// Whether the unit cell parameters have been changed, invalidating cached gF quantities.
+    bool unitCellHasChanged_;
+    /// Whether the kappa has been changed, invalidating kappa-dependent quantities.
+    bool kappaHasChanged_;
+    /// The type of alignment scheme used for the lattice vectors.
+    LatticeType latticeType_;
     /// Communication buffers for MPI parallelism.
     helpme::vector<Complex> workSpace1_, workSpace2_;
     /// FFTW wrappers to help with transformations in the {A,B,C} dimensions.
@@ -2276,6 +2326,19 @@ class PMEInstance {
                     ++count;
                 }
             }
+        }
+    }
+
+    /*!
+     * \brief updateInfluenceFunction builds the gF array cache, if the lattice vector has changed since the last
+     *                                build of it.  If the cell is unchanged, this does nothing.
+     */
+    void updateInfluenceFunction() {
+        if (unitCellHasChanged_ || kappaHasChanged_) {
+            cacheInfluenceFunctionFxn_(dimA_, dimB_, dimC_, myComplexDimA_, myDimB_ / numNodesC_,
+                                       rankA_ * myComplexDimA_, rankB_ * myDimB_ + rankC_ * myDimB_ / numNodesC_,
+                                       scaleFactor_, cachedInfluenceFunction_, recVecs_, cellVolume(), kappa_,
+                                       &splineModA_[0], &splineModB_[0], &splineModC_[0], nThreads_);
         }
     }
 
@@ -2777,7 +2840,7 @@ class PMEInstance {
             auto gammas = incompleteGammaVirialComputer<Real, 3 - rPower>::compute(bSquared);
             Real eGamma = std::get<0>(gammas);
             Real vGamma = std::get<1>(gammas);
-            Complex &gridVal = gridPtr[ky * nxz + kx * nz + kz];
+            Complex &gridVal = gridPtr[yxz];
             Real structFacNorm = std::norm(gridVal);
             Real totalPrefac = volPrefac * mTerm * yMods[ky + startY] * xMods[kx + startX] * zMods[kz];
             Real influenceFunction = totalPrefac * eGamma;
@@ -2803,6 +2866,77 @@ class PMEInstance {
         virial[0][5] -= Vzz - energy;
 
         return energy;
+    }
+    /*!
+     * \brief cacheInfluenceFunctionImpl computes the influence function used in convolution, for later use.
+     * \tparam rPower the exponent of the (inverse) distance kernel (e.g. 1 for Coulomb, 6 for attractive dispersion).
+     * \param nx the grid dimension in the x direction.
+     * \param ny the grid dimension in the y direction.
+     * \param nz the grid dimension in the z direction.
+     * \param myNx the subset of the grid in the x direction to be handled by this node.
+     * \param myNy the subset of the grid in the y direction to be handled by this node.
+     * \param startX the starting grid point handled by this node in the X direction.
+     * \param startY the starting grid point handled by this node in the Y direction.
+     * \param scaleFactor a scale factor to be applied to all computed energies and derivatives thereof (e.g. the
+     *        1 / [4 pi epslion0] for Coulomb calculations).
+     * \param gridPtr the Fourier space grid, with ordering YXZ.
+     * \param boxInv the reciprocal lattice vectors.
+     * \param volume the volume of the unit cell.
+     * \param kappa the attenuation parameter in units inverse of those used to specify coordinates.
+     * \param xMods the Fourier space norms of the x B-Splines.
+     * \param yMods the Fourier space norms of the y B-Splines.
+     * \param zMods the Fourier space norms of the z B-Splines.
+     *        This vector is incremented, not assigned.
+     * \param nThreads the number of OpenMP threads to use.
+     * \return the energy for the m=0 term.
+     */
+    template <int rPower>
+    static void cacheInfluenceFunctionImpl(int nx, int ny, int nz, int myNx, int myNy, int startX, int startY,
+                                           Real scaleFactor, RealVec &influenceFunction, const RealMat &boxInv,
+                                           Real volume, Real kappa, const Real *xMods, const Real *yMods,
+                                           const Real *zMods, int nThreads) {
+        bool nodeZero = startX == 0 && startY == 0;
+        size_t nxz = myNx * nz;
+        size_t nyxz = myNy * nxz;
+        influenceFunction.resize(nyxz);
+        Real *gridPtr = influenceFunction.data();
+        if (nodeZero) gridPtr[0] = 0;
+
+        std::vector<Real> xMVals(myNx), yMVals(myNy), zMVals(nz);
+        // Iterators to conveniently map {X,Y,Z} grid location to m_{X,Y,Z} value, where -1/2 << m/dim < 1/2.
+        for (int kx = 0; kx < myNx; ++kx) xMVals[kx] = startX + (kx + startX >= (nx + 1) / 2 ? kx - nx : kx);
+        for (int ky = 0; ky < myNy; ++ky) yMVals[ky] = startY + (ky + startY >= (ny + 1) / 2 ? ky - ny : ky);
+        for (int kz = 0; kz < nz; ++kz) zMVals[kz] = kz >= (nz + 1) / 2 ? kz - nz : kz;
+
+        Real bPrefac = M_PI * M_PI / (kappa * kappa);
+        Real volPrefac = scaleFactor * pow(M_PI, rPower - 1) / (sqrtPi * gammaComputer<Real, rPower>::value * volume);
+        int halfNx = nx / 2 + 1;
+        const Real *boxPtr = boxInv[0];
+        const Real *xMPtr = xMVals.data();
+        const Real *yMPtr = yMVals.data();
+        const Real *zMPtr = zMVals.data();
+        // Exclude m=0 cell.
+        int start = (nodeZero ? 1 : 0);
+// Writing the three nested loops in one allows for better load balancing in parallel.
+#pragma omp parallel for num_threads(nThreads)
+        for (size_t yxz = start; yxz < nyxz; ++yxz) {
+            size_t xz = yxz % nxz;
+            short ky = yxz / nxz;
+            short kx = xz / nz;
+            short kz = xz % nz;
+            Real mx = (Real)xMVals[kx];
+            Real my = (Real)yMVals[ky];
+            Real mz = (Real)zMVals[kz];
+            Real mVecX = boxPtr[0] * mx + boxPtr[1] * my + boxPtr[2] * mz;
+            Real mVecY = boxPtr[3] * mx + boxPtr[4] * my + boxPtr[5] * mz;
+            Real mVecZ = boxPtr[6] * mx + boxPtr[7] * my + boxPtr[8] * mz;
+            Real mNormSq = mVecX * mVecX + mVecY * mVecY + mVecZ * mVecZ;
+            Real mTerm = raiseNormToIntegerPower<Real, rPower - 3>::compute(mNormSq);
+            Real bSquared = bPrefac * mNormSq;
+            Real incompleteGammaTerm = incompleteGammaComputer<Real, 3 - rPower>::compute(bSquared);
+            gridPtr[yxz] =
+                volPrefac * incompleteGammaTerm * mTerm * yMods[ky + startY] * xMods[kx + startX] * zMods[kz];
+        }
     }
 
     /*!
@@ -2922,6 +3056,8 @@ class PMEInstance {
                      int nThreads) {
         if (rPower_ != rPower || kappa_ != kappa || splineOrder_ != splineOrder || dimA_ != dimA || dimB_ != dimB ||
             dimC_ != dimC || scaleFactor_ != scaleFactor || nThreads_ != nThreads) {
+            kappaHasChanged_ = kappa != kappa_;
+
             rPower_ = rPower;
 
             dimA_ = dimA;
@@ -2976,21 +3112,25 @@ class PMEInstance {
 
             workSpace1_ = helpme::vector<Complex>(myDimC_ * myComplexDimA_ * myDimB_);
             workSpace2_ = helpme::vector<Complex>(myDimC_ * myComplexDimA_ * myDimB_);
+
+        } else {
+            kappaHasChanged_ = false;
         }
     }
 
    public:
-    /*!
-     * \brief The different conventions for orienting a lattice constructed from input parameters.
-     */
-    enum class LatticeType : int { XAligned = 0, ShapeMatrix = 1 };
-
-    /*!
-     * \brief The different conventions for numbering nodes.
-     */
-    enum class NodeOrder : int { ZYX = 0 };
-
-    PMEInstance() : boxVecs_(3, 3), recVecs_(3, 3), scaledRecVecs_(3, 3), rPower_(0) {}
+    PMEInstance()
+        : boxVecs_(3, 3),
+          recVecs_(3, 3),
+          scaledRecVecs_(3, 3),
+          rPower_(0),
+          kappa_(0),
+          cellA_(0),
+          cellB_(0),
+          cellC_(0),
+          cellAlpha_(0),
+          cellBeta_(0),
+          cellGamma_(0) {}
 
     /*!
      * \brief cellVolume Compute the volume of the unit cell.
@@ -3017,51 +3157,57 @@ class PMEInstance {
      *           take the appropriate alignment to completely define the system.
      */
     void setLatticeVectors(Real A, Real B, Real C, Real alpha, Real beta, Real gamma, LatticeType latticeType) {
-        if (latticeType == LatticeType::ShapeMatrix) {
-            RealMat HtH(3, 3);
-            HtH(0, 0) = A * A;
-            HtH(1, 1) = B * B;
-            HtH(2, 2) = C * C;
-            const float TOL = 1e-4f;
-            // Check for angles very close to 90, to avoid noise from the eigensolver later on.
-            HtH(0, 1) = HtH(1, 0) = std::abs(gamma - 90) < TOL ? 0 : A * B * cos(M_PI * gamma / 180);
-            HtH(0, 2) = HtH(2, 0) = std::abs(beta - 90) < TOL ? 0 : A * C * cos(M_PI * beta / 180);
-            HtH(1, 2) = HtH(2, 1) = std::abs(alpha - 90) < TOL ? 0 : B * C * cos(M_PI * alpha / 180);
+        if (A != cellA_ || B != cellB_ || C != cellC_ || alpha != cellAlpha_ || beta != cellBeta_ ||
+            gamma != cellGamma_ || latticeType != latticeType_) {
+            if (latticeType == LatticeType::ShapeMatrix) {
+                RealMat HtH(3, 3);
+                HtH(0, 0) = A * A;
+                HtH(1, 1) = B * B;
+                HtH(2, 2) = C * C;
+                const float TOL = 1e-4f;
+                // Check for angles very close to 90, to avoid noise from the eigensolver later on.
+                HtH(0, 1) = HtH(1, 0) = std::abs(gamma - 90) < TOL ? 0 : A * B * cos(M_PI * gamma / 180);
+                HtH(0, 2) = HtH(2, 0) = std::abs(beta - 90) < TOL ? 0 : A * C * cos(M_PI * beta / 180);
+                HtH(1, 2) = HtH(2, 1) = std::abs(alpha - 90) < TOL ? 0 : B * C * cos(M_PI * alpha / 180);
 
-            auto eigenTuple = HtH.diagonalize();
-            RealMat evalsReal = std::get<0>(eigenTuple);
-            RealMat evalsImag = std::get<1>(eigenTuple);
-            RealMat evecs = std::get<2>(eigenTuple);
-            if (!evalsImag.isNearZero())
-                throw std::runtime_error("Unexpected complex eigenvalues encountered while making shape matrix.");
-            for (int i = 0; i < 3; ++i) evalsReal(i, 0) = sqrt(evalsReal(i, 0));
-            boxVecs_.setZero();
-            for (int i = 0; i < 3; ++i) {
-                for (int j = 0; j < 3; ++j) {
-                    for (int k = 0; k < 3; ++k) {
-                        boxVecs_(i, j) += evecs(i, k) * evecs(j, k) * evalsReal(k, 0);
+                auto eigenTuple = HtH.diagonalize();
+                RealMat evalsReal = std::get<0>(eigenTuple);
+                RealMat evalsImag = std::get<1>(eigenTuple);
+                RealMat evecs = std::get<2>(eigenTuple);
+                if (!evalsImag.isNearZero())
+                    throw std::runtime_error("Unexpected complex eigenvalues encountered while making shape matrix.");
+                for (int i = 0; i < 3; ++i) evalsReal(i, 0) = sqrt(evalsReal(i, 0));
+                boxVecs_.setZero();
+                for (int i = 0; i < 3; ++i) {
+                    for (int j = 0; j < 3; ++j) {
+                        for (int k = 0; k < 3; ++k) {
+                            boxVecs_(i, j) += evecs(i, k) * evecs(j, k) * evalsReal(k, 0);
+                        }
                     }
                 }
+                recVecs_ = boxVecs_.inverse();
+            } else if (latticeType == LatticeType::XAligned) {
+                boxVecs_(0, 0) = A;
+                boxVecs_(0, 1) = 0;
+                boxVecs_(0, 2) = 0;
+                boxVecs_(1, 0) = B * cos(M_PI / 180 * gamma);
+                boxVecs_(1, 1) = B * sin(M_PI / 180 * gamma);
+                boxVecs_(1, 2) = 0;
+                boxVecs_(2, 0) = C * cos(M_PI / 180 * beta);
+                boxVecs_(2, 1) = (B * C * cos(M_PI / 180 * alpha) - boxVecs_(2, 0) * boxVecs_(1, 0)) / boxVecs_(1, 1);
+                boxVecs_(2, 2) = sqrt(C * C - boxVecs_(2, 0) * boxVecs_(2, 0) - boxVecs_(2, 1) * boxVecs_(2, 1));
+            } else {
+                throw std::runtime_error("Unknown lattice type in setLatticeVectors");
             }
             recVecs_ = boxVecs_.inverse();
-        } else if (latticeType == LatticeType::XAligned) {
-            boxVecs_(0, 0) = A;
-            boxVecs_(0, 1) = 0;
-            boxVecs_(0, 2) = 0;
-            boxVecs_(1, 0) = B * cos(M_PI / 180 * gamma);
-            boxVecs_(1, 1) = B * sin(M_PI / 180 * gamma);
-            boxVecs_(1, 2) = 0;
-            boxVecs_(2, 0) = C * cos(M_PI / 180 * beta);
-            boxVecs_(2, 1) = (B * C * cos(M_PI / 180 * alpha) - boxVecs_(2, 0) * boxVecs_(1, 0)) / boxVecs_(1, 1);
-            boxVecs_(2, 2) = sqrt(C * C - boxVecs_(2, 0) * boxVecs_(2, 0) - boxVecs_(2, 1) * boxVecs_(2, 1));
+            scaledRecVecs_ = recVecs_.clone();
+            scaledRecVecs_.row(0) *= dimA_;
+            scaledRecVecs_.row(1) *= dimB_;
+            scaledRecVecs_.row(2) *= dimC_;
+            unitCellHasChanged_ = true;
         } else {
-            throw std::runtime_error("Unknown lattice type in setLatticeVectors");
+            unitCellHasChanged_ = false;
         }
-        recVecs_ = boxVecs_.inverse();
-        scaledRecVecs_ = recVecs_.clone();
-        scaledRecVecs_.row(0) *= dimA_;
-        scaledRecVecs_.row(1) *= dimB_;
-        scaledRecVecs_.row(2) *= dimC_;
     }
 
     /*!
@@ -3357,9 +3503,40 @@ class PMEInstance {
      * \return the reciprocal space energy.
      */
     Real convolveE(Complex *transformedGrid) {
-        return convolveEFxn_(dimA_, dimB_, dimC_, myComplexDimA_, myDimB_ / numNodesC_, rankA_ * myComplexDimA_,
-                             rankB_ * myDimB_ + rankC_ * myDimB_ / numNodesC_, scaleFactor_, transformedGrid, recVecs_,
-                             cellVolume(), kappa_, &splineModA_[0], &splineModB_[0], &splineModC_[0], nThreads_);
+        updateInfluenceFunction();
+        size_t myNy = myDimB_ / numNodesC_;
+        size_t myNx = myComplexDimA_;
+        size_t nz = dimC_;
+        size_t nxz = myNx * nz;
+        size_t nyxz = myNy * nxz;
+        size_t halfNx = dimA_ / 2 + 1;
+        bool iAmNodeZero = (rankA_ == 0 && rankB_ == 0 && rankC_ == 0);
+        Real *influenceFunction = cachedInfluenceFunction_.data();
+        int startX = rankA_ * myComplexDimA_;
+        int startY = rankB_ * myDimB_ + rankC_ * myDimB_ / numNodesC_;
+
+        Real energy = 0;
+        if (rPower_ > 3 && iAmNodeZero) {
+            // Kernels with rPower>3 are absolutely convergent and should have the m=0 term present.
+            // To compute it we need sum_ij c(i)c(j), which can be obtained from the structure factor norm.
+            Real prefac = 2 * scaleFactor_ * M_PI * sqrtPi * pow(kappa_, rPower_ - 3) /
+                          ((rPower_ - 3) * nonTemplateGammaComputer<Real>(rPower_) * cellVolume());
+            energy += prefac * std::norm(transformedGrid[0]);
+        }
+
+        transformedGrid[0] = Complex(0, 0);
+#pragma omp parallel for reduction(+ : energy) num_threads(nThreads_)
+        for (size_t yxz = 0; yxz < nyxz; ++yxz) {
+            size_t xz = yxz % nxz;
+            int kx = startX + xz / nz;
+            // We only loop over the first nx/2+1 x values; this
+            // accounts for the "missing" complex conjugate values.
+            Real permPrefac = kx != 0 && kx != halfNx - 1 ? 2 : 1;
+            Real structFactorNorm = std::norm(transformedGrid[yxz]);
+            energy += permPrefac * structFactorNorm * influenceFunction[yxz];
+            transformedGrid[yxz] *= influenceFunction[yxz];
+        }
+        return energy / 2;
     }
 
     /*!
@@ -3381,11 +3558,10 @@ class PMEInstance {
      *        use the various computeE() methods instead. This the more efficient version that filters
      *        the atom list and uses pre-computed splines.  Therefore, the splineCache_
      *        member must have been updated via a call to filterAtomsAndBuildSplineCache() first.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -3460,11 +3636,10 @@ class PMEInstance {
      *        use the various computeE() methods instead.  This is the slower version of this call that recomputes
      *        splines on demand and makes no assumptions about the integrity of the spline cache.
      * \param potentialGrid pointer to the array containing the potential, in ZYX order.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -3502,11 +3677,10 @@ class PMEInstance {
      *        member must have been updated via a call to filterAtomsAndBuildSplineCache() first.
      *
      * \param potentialGrid pointer to the array containing the potential, in ZYX order.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -3553,11 +3727,10 @@ class PMEInstance {
 
     /*!
      * \brief computeESlf computes the Ewald self interaction energy.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -3576,14 +3749,13 @@ class PMEInstance {
     }
 
     /*!
-     * \brief computeEDir computes the direct space energy.  This is provided mostly for debugging and testing purposes;
-     *        generally the host program should provide the pairwise interactions.
-     * \param pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \brief computeEDir computes the direct space energy.  This is provided mostly for debugging and testing
+     * purposes; generally the host program should provide the pairwise interactions. \param pairList dense list of
+     * atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN. \param parameterAngMom the angular momentum of
+     * the parameters (0 for charges, C6 coefficients, 2 for quadrupoles, etc.). \param parameters the list of
+     * parameters associated with each atom (charges, C6 coefficients, multipoles, etc...). For a parameter with
+     * angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the
+     * fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -3620,11 +3792,10 @@ class PMEInstance {
      * \brief computeEFDir computes the direct space energy and force.  This is provided mostly for debugging and
      * testing purposes; generally the host program should provide the pairwise interactions.
      * \param pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -3669,13 +3840,12 @@ class PMEInstance {
     }
 
     /*!
-     * \brief computeEFVDir computes the direct space energy, force and virial.  This is provided mostly for debugging
-     *        and testing purposes; generally the host program should provide the pairwise interactions.
-     * \param pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
+     * \brief computeEFVDir computes the direct space energy, force and virial.  This is provided mostly for
+     * debugging and testing purposes; generally the host program should provide the pairwise interactions. \param
+     * pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN. \param parameterAngMom
+     * the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles, etc.). \param
+     * parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles, etc...).
+     * For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
      * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
@@ -3730,15 +3900,14 @@ class PMEInstance {
     }
 
     /*!
-     * \brief computeEAdj computes the adjusted real space energy which extracts the energy for excluded pairs that is
-     *        present in reciprocal space. This is provided mostly for debugging and testing purposes; generally the
+     * \brief computeEAdj computes the adjusted real space energy which extracts the energy for excluded pairs that
+     * is present in reciprocal space. This is provided mostly for debugging and testing purposes; generally the
      *        host program should provide the pairwise interactions.
      * \param pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -3772,14 +3941,13 @@ class PMEInstance {
     }
 
     /*!
-     * \brief computeEFAdj computes the adjusted energy and force.  This is provided mostly for debugging and testing
-     * purposes; generally the host program should provide the pairwise interactions.
-     * \param pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \brief computeEFAdj computes the adjusted energy and force.  This is provided mostly for debugging and
+     * testing purposes; generally the host program should provide the pairwise interactions. \param pairList dense
+     * list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN. \param parameterAngMom the angular
+     * momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles, etc.). \param parameters the
+     * list of parameters associated with each atom (charges, C6 coefficients, multipoles, etc...). For a parameter
+     * with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL = (L+1)*(L+2)*(L+3)/6 and
+     * the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -3827,11 +3995,10 @@ class PMEInstance {
      * \brief computeEFVAdj computes the adjusted energy, forces and virial.  This is provided mostly for debugging
      *        and testing purposes; generally the host program should provide the pairwise interactions.
      * \param pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -3886,11 +4053,10 @@ class PMEInstance {
 
     /*!
      * \brief Runs a PME reciprocal space calculation, computing the potential and, optionally, its derivatives.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -3903,12 +4069,12 @@ class PMEInstance {
      * \endcode
      * \param coordinates the cartesian coordinates, ordered in memory as {x1,y1,z1,x2,y2,z2,....xN,yN,zN}.
      * \param energy pointer to the variable holding the energy; this is incremented, not assigned.
-     * \param gridPoints the list of grid points at which the potential is needed; can be the same as the coordinates.
-     * \param derivativeLevel the order of the potential derivatives required; 0 is the potential, 1 is (minus) the
-     * field, etc. \param potential the array holding the potential.  This is a matrix of dimensions nAtoms x nD, where
-     * nD is the derivative level requested.  See the details fo the parameters argument for information about ordering
-     * of derivative components. N.B. this array is incremented with the potential, not assigned, so take care to
-     * zero it first if only the current results are desired.
+     * \param gridPoints the list of grid points at which the potential is needed; can be the same as the
+     * coordinates. \param derivativeLevel the order of the potential derivatives required; 0 is the potential, 1 is
+     * (minus) the field, etc. \param potential the array holding the potential.  This is a matrix of dimensions
+     * nAtoms x nD, where nD is the derivative level requested.  See the details fo the parameters argument for
+     * information about ordering of derivative components. N.B. this array is incremented with the potential, not
+     * assigned, so take care to zero it first if only the current results are desired.
      */
     void computePRec(int parameterAngMom, const RealMat &parameters, const RealMat &coordinates,
                      const RealMat &gridPoints, int derivativeLevel, RealMat &potential) {
@@ -3939,11 +4105,10 @@ class PMEInstance {
 
     /*!
      * \brief Runs a PME reciprocal space calculation, computing energies.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -3969,11 +4134,10 @@ class PMEInstance {
 
     /*!
      * \brief Runs a PME reciprocal space calculation, computing energies and forces.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -4006,11 +4170,10 @@ class PMEInstance {
 
     /*!
      * \brief Runs a PME reciprocal space calculation, computing energies, forces and the virial.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -4051,11 +4214,10 @@ class PMEInstance {
      *        debugging.
      * \param includedList dense list of included atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN,jN.
      * \param excludedList dense list of excluded atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -4089,11 +4251,10 @@ class PMEInstance {
      *        and debugging.
      * \param includedList dense list of included atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
      * \param excludedList dense list of excluded atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -4127,11 +4288,10 @@ class PMEInstance {
      *        be used for testing and debugging.
      * \param includedList dense list of included atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
      * \param excludedList dense list of excluded atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -4164,16 +4324,16 @@ class PMEInstance {
     /*!
      * \brief setup initializes this object for a PME calculation using only threading.
      *        This may be called repeatedly without compromising performance.
-     * \param rPower the exponent of the (inverse) distance kernel (e.g. 1 for Coulomb, 6 for attractive dispersion).
-     * \param kappa the attenuation parameter in units inverse of those used to specify coordinates.
+     * \param rPower the exponent of the (inverse) distance kernel (e.g. 1 for Coulomb, 6 for attractive
+     * dispersion). \param kappa the attenuation parameter in units inverse of those used to specify coordinates.
      * \param splineOrder the order of B-spline; must be at least (2 + max. multipole order + deriv. level needed).
      * \param dimA the dimension of the FFT grid along the A axis.
      * \param dimB the dimension of the FFT grid along the B axis.
      * \param dimC the dimension of the FFT grid along the C axis.
      * \param scaleFactor a scale factor to be applied to all computed energies and derivatives thereof (e.g. the
      *        1 / [4 pi epslion0] for Coulomb calculations).
-     * \param nThreads the maximum number of threads to use for each MPI instance; if set to 0 all available threads are
-     *        used.
+     * \param nThreads the maximum number of threads to use for each MPI instance; if set to 0 all available threads
+     * are used.
      */
     void setup(int rPower, Real kappa, int splineOrder, int dimA, int dimB, int dimC, Real scaleFactor, int nThreads) {
         numNodesA_ = numNodesB_ = numNodesC_ = 1;
@@ -4194,16 +4354,16 @@ class PMEInstance {
     /*!
      * \brief setup initializes this object for a PME calculation using MPI parallism and threading.
      *        This may be called repeatedly without compromising performance.
-     * \param rPower the exponent of the (inverse) distance kernel (e.g. 1 for Coulomb, 6 for attractive dispersion).
-     * \param kappa the attenuation parameter in units inverse of those used to specify coordinates.
+     * \param rPower the exponent of the (inverse) distance kernel (e.g. 1 for Coulomb, 6 for attractive
+     * dispersion). \param kappa the attenuation parameter in units inverse of those used to specify coordinates.
      * \param splineOrder the order of B-spline; must be at least (2 + max. multipole order + deriv. level needed).
      * \param dimA the dimension of the FFT grid along the A axis.
      * \param dimB the dimension of the FFT grid along the B axis.
      * \param dimC the dimension of the FFT grid along the C axis.
      * \param scaleFactor a scale factor to be applied to all computed energies and derivatives thereof (e.g. the
      *        1 / [4 pi epslion0] for Coulomb calculations).
-     * \param nThreads the maximum number of threads to use for each MPI instance; if set to 0 all available threads are
-     * \param communicator the MPI communicator for the reciprocal space calcultion, which should already be
+     * \param nThreads the maximum number of threads to use for each MPI instance; if set to 0 all available threads
+     * are \param communicator the MPI communicator for the reciprocal space calcultion, which should already be
      *        initialized.
      * \param numNodesA the number of nodes to be used for the A dimension.
      * \param numNodesB the number of nodes to be used for the B dimension.
@@ -4247,7 +4407,8 @@ class PMEInstance {
 
 #else   // Have MPI
         throw std::runtime_error(
-            "setupParallel called, but helpme was not compiled with MPI.  Make sure you compile with -DHAVE_MPI=1 in "
+            "setupParallel called, but helpme was not compiled with MPI.  Make sure you compile with -DHAVE_MPI=1 "
+            "in "
             "the list of compiler definitions.");
 #endif  // Have MPI
     }

--- a/src/gamma.h
+++ b/src/gamma.h
@@ -366,5 +366,28 @@ struct gammaComputer {
     static constexpr Real value = gammaRecursion<Real, twoS, (twoS > 0)>::value;
 };
 
+/*!
+ * \brief Computes the Gamma function using recursion instead of template metaprogramming.
+ * \f$ \Gamma[s] = \int_0^\infty t^{s-1} e^{-t} \mathrm{d}t \f$
+ * In this code we only need half integral values for the \f$s\f$ argument, so the input
+ * argument \f$s\f$ will yield \f$\Gamma[\frac{s}{2}]\f$.
+ * \tparam Real the floating point type to use for arithmetic.
+ * \param twoS twice the s value required.
+ */
+template <typename Real>
+Real nonTemplateGammaComputer(int twoS) {
+    if (twoS == 1) {
+        return sqrtPi;
+    } else if (twoS == 2) {
+        return 1;
+    } else if (twoS <= 0 && twoS % 2 == 0) {
+        return std::numeric_limits<Real>::max();
+    } else if (twoS > 0) {
+        return nonTemplateGammaComputer<Real>(twoS - 2) * (0.5f * twoS - 1);
+    } else {
+        return nonTemplateGammaComputer<Real>(twoS + 2) / (0.5f * twoS);
+    }
+}
+
 }  // Namespace helpme
 #endif  // Header guard

--- a/src/helpme.h
+++ b/src/helpme.h
@@ -71,15 +71,16 @@ static int cartAddress(int lx, int ly, int lz) {
 }
 
 // This is used to define function pointers in the constructor, and makes it easy to add new kernels.
-#define ENABLE_KERNEL_WITH_INVERSE_R_EXPONENT_OF(n) \
-    case n:                                         \
-        convolveEFxn_ = &convolveEImpl<n>;          \
-        convolveEVFxn_ = &convolveEVImpl<n>;        \
-        slfEFxn_ = &slfEImpl<n>;                    \
-        dirEFxn_ = &dirEImpl<n>;                    \
-        adjEFxn_ = &adjEImpl<n>;                    \
-        dirEFFxn_ = &dirEFImpl<n>;                  \
-        adjEFFxn_ = &adjEFImpl<n>;                  \
+#define ENABLE_KERNEL_WITH_INVERSE_R_EXPONENT_OF(n)                  \
+    case n:                                                          \
+        convolveEFxn_ = &convolveEImpl<n>;                           \
+        convolveEVFxn_ = &convolveEVImpl<n>;                         \
+        cacheInfluenceFunctionFxn_ = &cacheInfluenceFunctionImpl<n>; \
+        slfEFxn_ = &slfEImpl<n>;                                     \
+        dirEFxn_ = &dirEImpl<n>;                                     \
+        adjEFxn_ = &adjEImpl<n>;                                     \
+        dirEFFxn_ = &dirEFImpl<n>;                                   \
+        adjEFFxn_ = &adjEFImpl<n>;                                   \
         break;
 
 /*!
@@ -114,6 +115,17 @@ class PMEInstance {
     using RealMat = Matrix<Real>;
     using RealVec = helpme::vector<Real>;
 
+   public:
+    /*!
+     * \brief The different conventions for orienting a lattice constructed from input parameters.
+     */
+    enum class LatticeType : int { XAligned = 0, ShapeMatrix = 1 };
+
+    /*!
+     * \brief The different conventions for numbering nodes.
+     */
+    enum class NodeOrder : int { ZYX = 0 };
+
    protected:
     /// The FFT grid dimensions in the {A,B,C} grid dimensions.
     int dimA_, dimB_, dimC_;
@@ -146,6 +158,8 @@ class PMEInstance {
     GridIterator gridIteratorA_, gridIteratorB_, gridIteratorC_;
     /// The (inverse) bspline moduli to normalize the spreading / probing steps; these are folded into the convolution.
     RealVec splineModA_, splineModB_, splineModC_;
+    /// The cached influence function involved in the convolution.
+    RealVec cachedInfluenceFunction_;
     /// A function pointer to call the approprate function to implement convolution, templated to the rPower value.
     std::function<Real(int, int, int, int, int, int, int, Real, Complex *, const RealMat &, Real, Real, const Real *,
                        const Real *, const Real *, int)>
@@ -155,6 +169,11 @@ class PMEInstance {
     std::function<Real(int, int, int, int, int, int, int, Real, Complex *, const RealMat &, Real, Real, const Real *,
                        const Real *, const Real *, RealMat &, int)>
         convolveEVFxn_;
+    /// A function pointer to call the approprate function to implement cacheing of the influence function that appears
+    //  in the convolution, templated to the rPower value.
+    std::function<void(int, int, int, int, int, int, int, Real, RealVec &, const RealMat &, Real, Real, const Real *,
+                       const Real *, const Real *, int)>
+        cacheInfluenceFunctionFxn_;
     /// A function pointer to call the approprate function to compute self energy, templated to the rPower value.
     std::function<Real(int, const RealMat &, Real, Real)> slfEFxn_;
     /// A function pointer to call the approprate function to compute the direct energy, templated to the rPower value.
@@ -188,6 +207,14 @@ class PMEInstance {
     int subsetOfCAlongA_, subsetOfCAlongB_, subsetOfBAlongC_;
     /// The size of a cache line, in units of the size of the Real type, to allow better memory allocation policies.
     Real cacheLineSizeInReals_;
+    /// The current unit cell parameters.
+    Real cellA_, cellB_, cellC_, cellAlpha_, cellBeta_, cellGamma_;
+    /// Whether the unit cell parameters have been changed, invalidating cached gF quantities.
+    bool unitCellHasChanged_;
+    /// Whether the kappa has been changed, invalidating kappa-dependent quantities.
+    bool kappaHasChanged_;
+    /// The type of alignment scheme used for the lattice vectors.
+    LatticeType latticeType_;
     /// Communication buffers for MPI parallelism.
     helpme::vector<Complex> workSpace1_, workSpace2_;
     /// FFTW wrappers to help with transformations in the {A,B,C} dimensions.
@@ -254,6 +281,19 @@ class PMEInstance {
                     ++count;
                 }
             }
+        }
+    }
+
+    /*!
+     * \brief updateInfluenceFunction builds the gF array cache, if the lattice vector has changed since the last
+     *                                build of it.  If the cell is unchanged, this does nothing.
+     */
+    void updateInfluenceFunction() {
+        if (unitCellHasChanged_ || kappaHasChanged_) {
+            cacheInfluenceFunctionFxn_(dimA_, dimB_, dimC_, myComplexDimA_, myDimB_ / numNodesC_,
+                                       rankA_ * myComplexDimA_, rankB_ * myDimB_ + rankC_ * myDimB_ / numNodesC_,
+                                       scaleFactor_, cachedInfluenceFunction_, recVecs_, cellVolume(), kappa_,
+                                       &splineModA_[0], &splineModB_[0], &splineModC_[0], nThreads_);
         }
     }
 
@@ -755,7 +795,7 @@ class PMEInstance {
             auto gammas = incompleteGammaVirialComputer<Real, 3 - rPower>::compute(bSquared);
             Real eGamma = std::get<0>(gammas);
             Real vGamma = std::get<1>(gammas);
-            Complex &gridVal = gridPtr[ky * nxz + kx * nz + kz];
+            Complex &gridVal = gridPtr[yxz];
             Real structFacNorm = std::norm(gridVal);
             Real totalPrefac = volPrefac * mTerm * yMods[ky + startY] * xMods[kx + startX] * zMods[kz];
             Real influenceFunction = totalPrefac * eGamma;
@@ -781,6 +821,77 @@ class PMEInstance {
         virial[0][5] -= Vzz - energy;
 
         return energy;
+    }
+    /*!
+     * \brief cacheInfluenceFunctionImpl computes the influence function used in convolution, for later use.
+     * \tparam rPower the exponent of the (inverse) distance kernel (e.g. 1 for Coulomb, 6 for attractive dispersion).
+     * \param nx the grid dimension in the x direction.
+     * \param ny the grid dimension in the y direction.
+     * \param nz the grid dimension in the z direction.
+     * \param myNx the subset of the grid in the x direction to be handled by this node.
+     * \param myNy the subset of the grid in the y direction to be handled by this node.
+     * \param startX the starting grid point handled by this node in the X direction.
+     * \param startY the starting grid point handled by this node in the Y direction.
+     * \param scaleFactor a scale factor to be applied to all computed energies and derivatives thereof (e.g. the
+     *        1 / [4 pi epslion0] for Coulomb calculations).
+     * \param gridPtr the Fourier space grid, with ordering YXZ.
+     * \param boxInv the reciprocal lattice vectors.
+     * \param volume the volume of the unit cell.
+     * \param kappa the attenuation parameter in units inverse of those used to specify coordinates.
+     * \param xMods the Fourier space norms of the x B-Splines.
+     * \param yMods the Fourier space norms of the y B-Splines.
+     * \param zMods the Fourier space norms of the z B-Splines.
+     *        This vector is incremented, not assigned.
+     * \param nThreads the number of OpenMP threads to use.
+     * \return the energy for the m=0 term.
+     */
+    template <int rPower>
+    static void cacheInfluenceFunctionImpl(int nx, int ny, int nz, int myNx, int myNy, int startX, int startY,
+                                           Real scaleFactor, RealVec &influenceFunction, const RealMat &boxInv,
+                                           Real volume, Real kappa, const Real *xMods, const Real *yMods,
+                                           const Real *zMods, int nThreads) {
+        bool nodeZero = startX == 0 && startY == 0;
+        size_t nxz = myNx * nz;
+        size_t nyxz = myNy * nxz;
+        influenceFunction.resize(nyxz);
+        Real *gridPtr = influenceFunction.data();
+        if (nodeZero) gridPtr[0] = 0;
+
+        std::vector<Real> xMVals(myNx), yMVals(myNy), zMVals(nz);
+        // Iterators to conveniently map {X,Y,Z} grid location to m_{X,Y,Z} value, where -1/2 << m/dim < 1/2.
+        for (int kx = 0; kx < myNx; ++kx) xMVals[kx] = startX + (kx + startX >= (nx + 1) / 2 ? kx - nx : kx);
+        for (int ky = 0; ky < myNy; ++ky) yMVals[ky] = startY + (ky + startY >= (ny + 1) / 2 ? ky - ny : ky);
+        for (int kz = 0; kz < nz; ++kz) zMVals[kz] = kz >= (nz + 1) / 2 ? kz - nz : kz;
+
+        Real bPrefac = M_PI * M_PI / (kappa * kappa);
+        Real volPrefac = scaleFactor * pow(M_PI, rPower - 1) / (sqrtPi * gammaComputer<Real, rPower>::value * volume);
+        int halfNx = nx / 2 + 1;
+        const Real *boxPtr = boxInv[0];
+        const Real *xMPtr = xMVals.data();
+        const Real *yMPtr = yMVals.data();
+        const Real *zMPtr = zMVals.data();
+        // Exclude m=0 cell.
+        int start = (nodeZero ? 1 : 0);
+// Writing the three nested loops in one allows for better load balancing in parallel.
+#pragma omp parallel for num_threads(nThreads)
+        for (size_t yxz = start; yxz < nyxz; ++yxz) {
+            size_t xz = yxz % nxz;
+            short ky = yxz / nxz;
+            short kx = xz / nz;
+            short kz = xz % nz;
+            Real mx = (Real)xMVals[kx];
+            Real my = (Real)yMVals[ky];
+            Real mz = (Real)zMVals[kz];
+            Real mVecX = boxPtr[0] * mx + boxPtr[1] * my + boxPtr[2] * mz;
+            Real mVecY = boxPtr[3] * mx + boxPtr[4] * my + boxPtr[5] * mz;
+            Real mVecZ = boxPtr[6] * mx + boxPtr[7] * my + boxPtr[8] * mz;
+            Real mNormSq = mVecX * mVecX + mVecY * mVecY + mVecZ * mVecZ;
+            Real mTerm = raiseNormToIntegerPower<Real, rPower - 3>::compute(mNormSq);
+            Real bSquared = bPrefac * mNormSq;
+            Real incompleteGammaTerm = incompleteGammaComputer<Real, 3 - rPower>::compute(bSquared);
+            gridPtr[yxz] =
+                volPrefac * incompleteGammaTerm * mTerm * yMods[ky + startY] * xMods[kx + startX] * zMods[kz];
+        }
     }
 
     /*!
@@ -900,6 +1011,8 @@ class PMEInstance {
                      int nThreads) {
         if (rPower_ != rPower || kappa_ != kappa || splineOrder_ != splineOrder || dimA_ != dimA || dimB_ != dimB ||
             dimC_ != dimC || scaleFactor_ != scaleFactor || nThreads_ != nThreads) {
+            kappaHasChanged_ = kappa != kappa_;
+
             rPower_ = rPower;
 
             dimA_ = dimA;
@@ -954,21 +1067,25 @@ class PMEInstance {
 
             workSpace1_ = helpme::vector<Complex>(myDimC_ * myComplexDimA_ * myDimB_);
             workSpace2_ = helpme::vector<Complex>(myDimC_ * myComplexDimA_ * myDimB_);
+
+        } else {
+            kappaHasChanged_ = false;
         }
     }
 
    public:
-    /*!
-     * \brief The different conventions for orienting a lattice constructed from input parameters.
-     */
-    enum class LatticeType : int { XAligned = 0, ShapeMatrix = 1 };
-
-    /*!
-     * \brief The different conventions for numbering nodes.
-     */
-    enum class NodeOrder : int { ZYX = 0 };
-
-    PMEInstance() : boxVecs_(3, 3), recVecs_(3, 3), scaledRecVecs_(3, 3), rPower_(0) {}
+    PMEInstance()
+        : boxVecs_(3, 3),
+          recVecs_(3, 3),
+          scaledRecVecs_(3, 3),
+          rPower_(0),
+          kappa_(0),
+          cellA_(0),
+          cellB_(0),
+          cellC_(0),
+          cellAlpha_(0),
+          cellBeta_(0),
+          cellGamma_(0) {}
 
     /*!
      * \brief cellVolume Compute the volume of the unit cell.
@@ -995,51 +1112,57 @@ class PMEInstance {
      *           take the appropriate alignment to completely define the system.
      */
     void setLatticeVectors(Real A, Real B, Real C, Real alpha, Real beta, Real gamma, LatticeType latticeType) {
-        if (latticeType == LatticeType::ShapeMatrix) {
-            RealMat HtH(3, 3);
-            HtH(0, 0) = A * A;
-            HtH(1, 1) = B * B;
-            HtH(2, 2) = C * C;
-            const float TOL = 1e-4f;
-            // Check for angles very close to 90, to avoid noise from the eigensolver later on.
-            HtH(0, 1) = HtH(1, 0) = std::abs(gamma - 90) < TOL ? 0 : A * B * cos(M_PI * gamma / 180);
-            HtH(0, 2) = HtH(2, 0) = std::abs(beta - 90) < TOL ? 0 : A * C * cos(M_PI * beta / 180);
-            HtH(1, 2) = HtH(2, 1) = std::abs(alpha - 90) < TOL ? 0 : B * C * cos(M_PI * alpha / 180);
+        if (A != cellA_ || B != cellB_ || C != cellC_ || alpha != cellAlpha_ || beta != cellBeta_ ||
+            gamma != cellGamma_ || latticeType != latticeType_) {
+            if (latticeType == LatticeType::ShapeMatrix) {
+                RealMat HtH(3, 3);
+                HtH(0, 0) = A * A;
+                HtH(1, 1) = B * B;
+                HtH(2, 2) = C * C;
+                const float TOL = 1e-4f;
+                // Check for angles very close to 90, to avoid noise from the eigensolver later on.
+                HtH(0, 1) = HtH(1, 0) = std::abs(gamma - 90) < TOL ? 0 : A * B * cos(M_PI * gamma / 180);
+                HtH(0, 2) = HtH(2, 0) = std::abs(beta - 90) < TOL ? 0 : A * C * cos(M_PI * beta / 180);
+                HtH(1, 2) = HtH(2, 1) = std::abs(alpha - 90) < TOL ? 0 : B * C * cos(M_PI * alpha / 180);
 
-            auto eigenTuple = HtH.diagonalize();
-            RealMat evalsReal = std::get<0>(eigenTuple);
-            RealMat evalsImag = std::get<1>(eigenTuple);
-            RealMat evecs = std::get<2>(eigenTuple);
-            if (!evalsImag.isNearZero())
-                throw std::runtime_error("Unexpected complex eigenvalues encountered while making shape matrix.");
-            for (int i = 0; i < 3; ++i) evalsReal(i, 0) = sqrt(evalsReal(i, 0));
-            boxVecs_.setZero();
-            for (int i = 0; i < 3; ++i) {
-                for (int j = 0; j < 3; ++j) {
-                    for (int k = 0; k < 3; ++k) {
-                        boxVecs_(i, j) += evecs(i, k) * evecs(j, k) * evalsReal(k, 0);
+                auto eigenTuple = HtH.diagonalize();
+                RealMat evalsReal = std::get<0>(eigenTuple);
+                RealMat evalsImag = std::get<1>(eigenTuple);
+                RealMat evecs = std::get<2>(eigenTuple);
+                if (!evalsImag.isNearZero())
+                    throw std::runtime_error("Unexpected complex eigenvalues encountered while making shape matrix.");
+                for (int i = 0; i < 3; ++i) evalsReal(i, 0) = sqrt(evalsReal(i, 0));
+                boxVecs_.setZero();
+                for (int i = 0; i < 3; ++i) {
+                    for (int j = 0; j < 3; ++j) {
+                        for (int k = 0; k < 3; ++k) {
+                            boxVecs_(i, j) += evecs(i, k) * evecs(j, k) * evalsReal(k, 0);
+                        }
                     }
                 }
+                recVecs_ = boxVecs_.inverse();
+            } else if (latticeType == LatticeType::XAligned) {
+                boxVecs_(0, 0) = A;
+                boxVecs_(0, 1) = 0;
+                boxVecs_(0, 2) = 0;
+                boxVecs_(1, 0) = B * cos(M_PI / 180 * gamma);
+                boxVecs_(1, 1) = B * sin(M_PI / 180 * gamma);
+                boxVecs_(1, 2) = 0;
+                boxVecs_(2, 0) = C * cos(M_PI / 180 * beta);
+                boxVecs_(2, 1) = (B * C * cos(M_PI / 180 * alpha) - boxVecs_(2, 0) * boxVecs_(1, 0)) / boxVecs_(1, 1);
+                boxVecs_(2, 2) = sqrt(C * C - boxVecs_(2, 0) * boxVecs_(2, 0) - boxVecs_(2, 1) * boxVecs_(2, 1));
+            } else {
+                throw std::runtime_error("Unknown lattice type in setLatticeVectors");
             }
             recVecs_ = boxVecs_.inverse();
-        } else if (latticeType == LatticeType::XAligned) {
-            boxVecs_(0, 0) = A;
-            boxVecs_(0, 1) = 0;
-            boxVecs_(0, 2) = 0;
-            boxVecs_(1, 0) = B * cos(M_PI / 180 * gamma);
-            boxVecs_(1, 1) = B * sin(M_PI / 180 * gamma);
-            boxVecs_(1, 2) = 0;
-            boxVecs_(2, 0) = C * cos(M_PI / 180 * beta);
-            boxVecs_(2, 1) = (B * C * cos(M_PI / 180 * alpha) - boxVecs_(2, 0) * boxVecs_(1, 0)) / boxVecs_(1, 1);
-            boxVecs_(2, 2) = sqrt(C * C - boxVecs_(2, 0) * boxVecs_(2, 0) - boxVecs_(2, 1) * boxVecs_(2, 1));
+            scaledRecVecs_ = recVecs_.clone();
+            scaledRecVecs_.row(0) *= dimA_;
+            scaledRecVecs_.row(1) *= dimB_;
+            scaledRecVecs_.row(2) *= dimC_;
+            unitCellHasChanged_ = true;
         } else {
-            throw std::runtime_error("Unknown lattice type in setLatticeVectors");
+            unitCellHasChanged_ = false;
         }
-        recVecs_ = boxVecs_.inverse();
-        scaledRecVecs_ = recVecs_.clone();
-        scaledRecVecs_.row(0) *= dimA_;
-        scaledRecVecs_.row(1) *= dimB_;
-        scaledRecVecs_.row(2) *= dimC_;
     }
 
     /*!
@@ -1335,9 +1458,40 @@ class PMEInstance {
      * \return the reciprocal space energy.
      */
     Real convolveE(Complex *transformedGrid) {
-        return convolveEFxn_(dimA_, dimB_, dimC_, myComplexDimA_, myDimB_ / numNodesC_, rankA_ * myComplexDimA_,
-                             rankB_ * myDimB_ + rankC_ * myDimB_ / numNodesC_, scaleFactor_, transformedGrid, recVecs_,
-                             cellVolume(), kappa_, &splineModA_[0], &splineModB_[0], &splineModC_[0], nThreads_);
+        updateInfluenceFunction();
+        size_t myNy = myDimB_ / numNodesC_;
+        size_t myNx = myComplexDimA_;
+        size_t nz = dimC_;
+        size_t nxz = myNx * nz;
+        size_t nyxz = myNy * nxz;
+        size_t halfNx = dimA_ / 2 + 1;
+        bool iAmNodeZero = (rankA_ == 0 && rankB_ == 0 && rankC_ == 0);
+        Real *influenceFunction = cachedInfluenceFunction_.data();
+        int startX = rankA_ * myComplexDimA_;
+        int startY = rankB_ * myDimB_ + rankC_ * myDimB_ / numNodesC_;
+
+        Real energy = 0;
+        if (rPower_ > 3 && iAmNodeZero) {
+            // Kernels with rPower>3 are absolutely convergent and should have the m=0 term present.
+            // To compute it we need sum_ij c(i)c(j), which can be obtained from the structure factor norm.
+            Real prefac = 2 * scaleFactor_ * M_PI * sqrtPi * pow(kappa_, rPower_ - 3) /
+                          ((rPower_ - 3) * nonTemplateGammaComputer<Real>(rPower_) * cellVolume());
+            energy += prefac * std::norm(transformedGrid[0]);
+        }
+
+        transformedGrid[0] = Complex(0, 0);
+#pragma omp parallel for reduction(+ : energy) num_threads(nThreads_)
+        for (size_t yxz = 0; yxz < nyxz; ++yxz) {
+            size_t xz = yxz % nxz;
+            int kx = startX + xz / nz;
+            // We only loop over the first nx/2+1 x values; this
+            // accounts for the "missing" complex conjugate values.
+            Real permPrefac = kx != 0 && kx != halfNx - 1 ? 2 : 1;
+            Real structFactorNorm = std::norm(transformedGrid[yxz]);
+            energy += permPrefac * structFactorNorm * influenceFunction[yxz];
+            transformedGrid[yxz] *= influenceFunction[yxz];
+        }
+        return energy / 2;
     }
 
     /*!
@@ -1359,11 +1513,10 @@ class PMEInstance {
      *        use the various computeE() methods instead. This the more efficient version that filters
      *        the atom list and uses pre-computed splines.  Therefore, the splineCache_
      *        member must have been updated via a call to filterAtomsAndBuildSplineCache() first.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -1438,11 +1591,10 @@ class PMEInstance {
      *        use the various computeE() methods instead.  This is the slower version of this call that recomputes
      *        splines on demand and makes no assumptions about the integrity of the spline cache.
      * \param potentialGrid pointer to the array containing the potential, in ZYX order.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -1480,11 +1632,10 @@ class PMEInstance {
      *        member must have been updated via a call to filterAtomsAndBuildSplineCache() first.
      *
      * \param potentialGrid pointer to the array containing the potential, in ZYX order.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -1531,11 +1682,10 @@ class PMEInstance {
 
     /*!
      * \brief computeESlf computes the Ewald self interaction energy.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -1554,14 +1704,13 @@ class PMEInstance {
     }
 
     /*!
-     * \brief computeEDir computes the direct space energy.  This is provided mostly for debugging and testing purposes;
-     *        generally the host program should provide the pairwise interactions.
-     * \param pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \brief computeEDir computes the direct space energy.  This is provided mostly for debugging and testing
+     * purposes; generally the host program should provide the pairwise interactions. \param pairList dense list of
+     * atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN. \param parameterAngMom the angular momentum of
+     * the parameters (0 for charges, C6 coefficients, 2 for quadrupoles, etc.). \param parameters the list of
+     * parameters associated with each atom (charges, C6 coefficients, multipoles, etc...). For a parameter with
+     * angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the
+     * fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -1598,11 +1747,10 @@ class PMEInstance {
      * \brief computeEFDir computes the direct space energy and force.  This is provided mostly for debugging and
      * testing purposes; generally the host program should provide the pairwise interactions.
      * \param pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -1647,13 +1795,12 @@ class PMEInstance {
     }
 
     /*!
-     * \brief computeEFVDir computes the direct space energy, force and virial.  This is provided mostly for debugging
-     *        and testing purposes; generally the host program should provide the pairwise interactions.
-     * \param pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
+     * \brief computeEFVDir computes the direct space energy, force and virial.  This is provided mostly for
+     * debugging and testing purposes; generally the host program should provide the pairwise interactions. \param
+     * pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN. \param parameterAngMom
+     * the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles, etc.). \param
+     * parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles, etc...).
+     * For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
      * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
@@ -1708,15 +1855,14 @@ class PMEInstance {
     }
 
     /*!
-     * \brief computeEAdj computes the adjusted real space energy which extracts the energy for excluded pairs that is
-     *        present in reciprocal space. This is provided mostly for debugging and testing purposes; generally the
+     * \brief computeEAdj computes the adjusted real space energy which extracts the energy for excluded pairs that
+     * is present in reciprocal space. This is provided mostly for debugging and testing purposes; generally the
      *        host program should provide the pairwise interactions.
      * \param pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -1750,14 +1896,13 @@ class PMEInstance {
     }
 
     /*!
-     * \brief computeEFAdj computes the adjusted energy and force.  This is provided mostly for debugging and testing
-     * purposes; generally the host program should provide the pairwise interactions.
-     * \param pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \brief computeEFAdj computes the adjusted energy and force.  This is provided mostly for debugging and
+     * testing purposes; generally the host program should provide the pairwise interactions. \param pairList dense
+     * list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN. \param parameterAngMom the angular
+     * momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles, etc.). \param parameters the
+     * list of parameters associated with each atom (charges, C6 coefficients, multipoles, etc...). For a parameter
+     * with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL = (L+1)*(L+2)*(L+3)/6 and
+     * the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -1805,11 +1950,10 @@ class PMEInstance {
      * \brief computeEFVAdj computes the adjusted energy, forces and virial.  This is provided mostly for debugging
      *        and testing purposes; generally the host program should provide the pairwise interactions.
      * \param pairList dense list of atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -1864,11 +2008,10 @@ class PMEInstance {
 
     /*!
      * \brief Runs a PME reciprocal space calculation, computing the potential and, optionally, its derivatives.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -1881,12 +2024,12 @@ class PMEInstance {
      * \endcode
      * \param coordinates the cartesian coordinates, ordered in memory as {x1,y1,z1,x2,y2,z2,....xN,yN,zN}.
      * \param energy pointer to the variable holding the energy; this is incremented, not assigned.
-     * \param gridPoints the list of grid points at which the potential is needed; can be the same as the coordinates.
-     * \param derivativeLevel the order of the potential derivatives required; 0 is the potential, 1 is (minus) the
-     * field, etc. \param potential the array holding the potential.  This is a matrix of dimensions nAtoms x nD, where
-     * nD is the derivative level requested.  See the details fo the parameters argument for information about ordering
-     * of derivative components. N.B. this array is incremented with the potential, not assigned, so take care to
-     * zero it first if only the current results are desired.
+     * \param gridPoints the list of grid points at which the potential is needed; can be the same as the
+     * coordinates. \param derivativeLevel the order of the potential derivatives required; 0 is the potential, 1 is
+     * (minus) the field, etc. \param potential the array holding the potential.  This is a matrix of dimensions
+     * nAtoms x nD, where nD is the derivative level requested.  See the details fo the parameters argument for
+     * information about ordering of derivative components. N.B. this array is incremented with the potential, not
+     * assigned, so take care to zero it first if only the current results are desired.
      */
     void computePRec(int parameterAngMom, const RealMat &parameters, const RealMat &coordinates,
                      const RealMat &gridPoints, int derivativeLevel, RealMat &potential) {
@@ -1917,11 +2060,10 @@ class PMEInstance {
 
     /*!
      * \brief Runs a PME reciprocal space calculation, computing energies.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -1947,11 +2089,10 @@ class PMEInstance {
 
     /*!
      * \brief Runs a PME reciprocal space calculation, computing energies and forces.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -1984,11 +2125,10 @@ class PMEInstance {
 
     /*!
      * \brief Runs a PME reciprocal space calculation, computing energies, forces and the virial.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -2029,11 +2169,10 @@ class PMEInstance {
      *        debugging.
      * \param includedList dense list of included atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN,jN.
      * \param excludedList dense list of excluded atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -2067,11 +2206,10 @@ class PMEInstance {
      *        and debugging.
      * \param includedList dense list of included atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
      * \param excludedList dense list of excluded atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -2105,11 +2243,10 @@ class PMEInstance {
      *        be used for testing and debugging.
      * \param includedList dense list of included atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
      * \param excludedList dense list of excluded atom pairs, ordered like i1, j1, i2, j2, i3, j3, ... iN, jN.
-     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for quadrupoles,
-     * etc.).
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param parameterAngMom the angular momentum of the parameters (0 for charges, C6 coefficients, 2 for
+     * quadrupoles, etc.). \param parameters the list of parameters associated with each atom (charges, C6
+     * coefficients, multipoles, etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL
+     * is expected, where nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -2142,16 +2279,16 @@ class PMEInstance {
     /*!
      * \brief setup initializes this object for a PME calculation using only threading.
      *        This may be called repeatedly without compromising performance.
-     * \param rPower the exponent of the (inverse) distance kernel (e.g. 1 for Coulomb, 6 for attractive dispersion).
-     * \param kappa the attenuation parameter in units inverse of those used to specify coordinates.
+     * \param rPower the exponent of the (inverse) distance kernel (e.g. 1 for Coulomb, 6 for attractive
+     * dispersion). \param kappa the attenuation parameter in units inverse of those used to specify coordinates.
      * \param splineOrder the order of B-spline; must be at least (2 + max. multipole order + deriv. level needed).
      * \param dimA the dimension of the FFT grid along the A axis.
      * \param dimB the dimension of the FFT grid along the B axis.
      * \param dimC the dimension of the FFT grid along the C axis.
      * \param scaleFactor a scale factor to be applied to all computed energies and derivatives thereof (e.g. the
      *        1 / [4 pi epslion0] for Coulomb calculations).
-     * \param nThreads the maximum number of threads to use for each MPI instance; if set to 0 all available threads are
-     *        used.
+     * \param nThreads the maximum number of threads to use for each MPI instance; if set to 0 all available threads
+     * are used.
      */
     void setup(int rPower, Real kappa, int splineOrder, int dimA, int dimB, int dimC, Real scaleFactor, int nThreads) {
         numNodesA_ = numNodesB_ = numNodesC_ = 1;
@@ -2172,16 +2309,16 @@ class PMEInstance {
     /*!
      * \brief setup initializes this object for a PME calculation using MPI parallism and threading.
      *        This may be called repeatedly without compromising performance.
-     * \param rPower the exponent of the (inverse) distance kernel (e.g. 1 for Coulomb, 6 for attractive dispersion).
-     * \param kappa the attenuation parameter in units inverse of those used to specify coordinates.
+     * \param rPower the exponent of the (inverse) distance kernel (e.g. 1 for Coulomb, 6 for attractive
+     * dispersion). \param kappa the attenuation parameter in units inverse of those used to specify coordinates.
      * \param splineOrder the order of B-spline; must be at least (2 + max. multipole order + deriv. level needed).
      * \param dimA the dimension of the FFT grid along the A axis.
      * \param dimB the dimension of the FFT grid along the B axis.
      * \param dimC the dimension of the FFT grid along the C axis.
      * \param scaleFactor a scale factor to be applied to all computed energies and derivatives thereof (e.g. the
      *        1 / [4 pi epslion0] for Coulomb calculations).
-     * \param nThreads the maximum number of threads to use for each MPI instance; if set to 0 all available threads are
-     * \param communicator the MPI communicator for the reciprocal space calcultion, which should already be
+     * \param nThreads the maximum number of threads to use for each MPI instance; if set to 0 all available threads
+     * are \param communicator the MPI communicator for the reciprocal space calcultion, which should already be
      *        initialized.
      * \param numNodesA the number of nodes to be used for the A dimension.
      * \param numNodesB the number of nodes to be used for the B dimension.
@@ -2225,7 +2362,8 @@ class PMEInstance {
 
 #else   // Have MPI
         throw std::runtime_error(
-            "setupParallel called, but helpme was not compiled with MPI.  Make sure you compile with -DHAVE_MPI=1 in "
+            "setupParallel called, but helpme was not compiled with MPI.  Make sure you compile with -DHAVE_MPI=1 "
+            "in "
             "the list of compiler definitions.");
 #endif  // Have MPI
     }

--- a/src/helpme.h
+++ b/src/helpme.h
@@ -208,6 +208,16 @@ class PMEInstance {
     bool unitCellHasChanged_;
     /// Whether the kappa has been changed, invalidating kappa-dependent quantities.
     bool kappaHasChanged_;
+    /// Whether any of the grid dimensions have changed.
+    bool gridDimensionHasChanged_;
+    /// Whether the spline order has changed.
+    bool splineOrderHasChanged_;
+    /// Whether the scale factor has changed.
+    bool scaleFactorHasChanged_;
+    /// Whether the power of R has changed.
+    bool rPowerHasChanged_;
+    /// Whether the parallel node setup has changed in any way.
+    bool numNodesHasChanged_;
     /// The type of alignment scheme used for the lattice vectors.
     LatticeType latticeType_;
     /// Communication buffers for MPI parallelism.
@@ -284,7 +294,8 @@ class PMEInstance {
      *                                build of it.  If the cell is unchanged, this does nothing.
      */
     void updateInfluenceFunction() {
-        if (unitCellHasChanged_ || kappaHasChanged_) {
+        if (unitCellHasChanged_ || kappaHasChanged_ || gridDimensionHasChanged_ || splineOrderHasChanged_ ||
+            scaleFactorHasChanged_ || numNodesHasChanged_) {
             cacheInfluenceFunctionFxn_(dimA_, dimB_, dimC_, myComplexDimA_, myDimB_ / numNodesC_,
                                        rankA_ * myComplexDimA_, rankB_ * myDimB_ + rankC_ * myDimB_ / numNodesC_,
                                        scaleFactor_, cachedInfluenceFunction_, recVecs_, cellVolume(), kappa_,
@@ -921,10 +932,13 @@ class PMEInstance {
      */
     void common_init(int rPower, Real kappa, int splineOrder, int dimA, int dimB, int dimC, Real scaleFactor,
                      int nThreads) {
-        if (rPower_ != rPower || kappa_ != kappa || splineOrder_ != splineOrder || dimA_ != dimA || dimB_ != dimB ||
-            dimC_ != dimC || scaleFactor_ != scaleFactor || nThreads_ != nThreads) {
-            kappaHasChanged_ = kappa != kappa_;
-
+        kappaHasChanged_ = kappa != kappa_;
+        rPowerHasChanged_ = rPower_ != rPower;
+        gridDimensionHasChanged_ = dimA_ != dimA || dimB_ != dimB || dimC_ != dimC;
+        splineOrderHasChanged_ = splineOrder_ != splineOrder;
+        scaleFactorHasChanged_ = scaleFactor_ != scaleFactor;
+        if (kappaHasChanged_ || rPowerHasChanged_ || gridDimensionHasChanged_ || splineOrderHasChanged_ ||
+            scaleFactorHasChanged_ || nThreads_ != nThreads) {
             rPower_ = rPower;
 
             dimA_ = dimA;
@@ -979,9 +993,6 @@ class PMEInstance {
 
             workSpace1_ = helpme::vector<Complex>(myDimC_ * myComplexDimA_ * myDimB_);
             workSpace2_ = helpme::vector<Complex>(myDimC_ * myComplexDimA_ * myDimB_);
-
-        } else {
-            kappaHasChanged_ = false;
         }
     }
 
@@ -991,10 +1002,18 @@ class PMEInstance {
           recVecs_(3, 3),
           scaledRecVecs_(3, 3),
           rPower_(0),
+          scaleFactor_(0),
+          dimA_(0),
+          dimB_(0),
+          dimC_(0),
+          splineOrder_(0),
           kappa_(0),
           cellA_(0),
           cellB_(0),
           cellC_(0),
+          numNodesA_(1),
+          numNodesB_(1),
+          numNodesC_(1),
           cellAlpha_(0),
           cellBeta_(0),
           cellGamma_(0) {}
@@ -2203,6 +2222,7 @@ class PMEInstance {
      * are used.
      */
     void setup(int rPower, Real kappa, int splineOrder, int dimA, int dimB, int dimC, Real scaleFactor, int nThreads) {
+        numNodesHasChanged_ = numNodesA_ != 1 || numNodesB_ != 1 || numNodesC_ != 1;
         numNodesA_ = numNodesB_ = numNodesC_ = 1;
         rankA_ = rankB_ = rankC_ = 0;
         firstA_ = firstB_ = firstC_ = 0;
@@ -2239,6 +2259,7 @@ class PMEInstance {
     void setupParallel(int rPower, Real kappa, int splineOrder, int dimA, int dimB, int dimC, Real scaleFactor,
                        int nThreads, const MPI_Comm &communicator, NodeOrder nodeOrder, int numNodesA, int numNodesB,
                        int numNodesC) {
+        numNodesHasChanged_ = numNodesA_ != numNodesA || numNodesB_ != numNodesB || numNodesC_ != numNodesC;
 #if HAVE_MPI == 1
         mpiCommunicator_ =
             std::unique_ptr<MPIWrapper<Real>>(new MPIWrapper<Real>(communicator, numNodesA, numNodesB, numNodesC));

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -7,6 +7,7 @@ set( SOURCES_UNITTESTS_TESTS
     unittest-gammafunction.cpp
     unittest-gridsize.cpp
     unittest-lattice.cpp
+    unittest-latticeupdates.cpp
     unittest-matrix.cpp
     unittest-powers.cpp
     unittest-potential.cpp

--- a/test/unittests/unittest-gammafunction.cpp
+++ b/test/unittests/unittest-gammafunction.cpp
@@ -37,6 +37,25 @@ TEST_CASE("test the gamma function and incomplete gamma function.") {
         gamma = helpme::gammaComputer<double, 4>::value;
         REQUIRE(gamma == Approx(1.0).margin(TOL));
 
+        gamma = helpme::nonTemplateGammaComputer<double>(-4);
+        REQUIRE(gamma == Approx(std::numeric_limits<double>::max()).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<double>(-3);
+        REQUIRE(gamma == Approx(2.363271801).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<double>(-2);
+        REQUIRE(gamma == Approx(std::numeric_limits<double>::max()).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<double>(-1);
+        REQUIRE(gamma == Approx(-3.544907702).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<double>(0);
+        REQUIRE(gamma == Approx(std::numeric_limits<double>::max()).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<double>(1);
+        REQUIRE(gamma == Approx(1.772453851).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<double>(2);
+        REQUIRE(gamma == Approx(1.0).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<double>(3);
+        REQUIRE(gamma == Approx(8.862269255e-1).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<double>(4);
+        REQUIRE(gamma == Approx(1.0).margin(TOL));
+
         REQUIRE(helpme::incompleteGammaComputer<double, -4>::compute(0.1) == Approx(4.162914579e1).margin(TOL));
         REQUIRE(helpme::incompleteGammaComputer<double, -3>::compute(0.1) == Approx(1.680780146e1).margin(TOL));
         REQUIRE(helpme::incompleteGammaComputer<double, -2>::compute(0.1) == Approx(7.225450222).margin(TOL));
@@ -117,6 +136,25 @@ TEST_CASE("test the gamma function and incomplete gamma function.") {
         gamma = helpme::gammaComputer<float, 3>::value;
         REQUIRE(gamma == Approx(8.862269255e-1f).margin(TOL));
         gamma = helpme::gammaComputer<float, 4>::value;
+        REQUIRE(gamma == Approx(1.0f).margin(TOL));
+
+        gamma = helpme::nonTemplateGammaComputer<float>(-4);
+        REQUIRE(gamma == Approx(std::numeric_limits<float>::max()).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<float>(-3);
+        REQUIRE(gamma == Approx(2.363271801f).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<float>(-2);
+        REQUIRE(gamma == Approx(std::numeric_limits<float>::max()).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<float>(-1);
+        REQUIRE(gamma == Approx(-3.544907702f).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<float>(0);
+        REQUIRE(gamma == Approx(std::numeric_limits<float>::max()).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<float>(1);
+        REQUIRE(gamma == Approx(1.772453851f).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<float>(2);
+        REQUIRE(gamma == Approx(1.0f).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<float>(3);
+        REQUIRE(gamma == Approx(8.862269255e-1f).margin(TOL));
+        gamma = helpme::nonTemplateGammaComputer<float>(4);
         REQUIRE(gamma == Approx(1.0f).margin(TOL));
 
         REQUIRE(helpme::incompleteGammaComputer<float, -4>::compute(0.1) == Approx(4.162914579e1f).margin(TOL));

--- a/test/unittests/unittest-latticeupdates.cpp
+++ b/test/unittests/unittest-latticeupdates.cpp
@@ -1,0 +1,303 @@
+// BEGINLICENSE
+//
+// This file is part of helPME, which is distributed under the BSD 3-clause license,
+// as described in the LICENSE file in the top level directory of this project.
+//
+// Author: Andrew C. Simmonett
+//
+// ENDLICENSE
+
+#include "catch.hpp"
+
+#include "helpme.h"
+
+TEST_CASE("check that updates of kappa and unit cell parameters give the correct behavior.") {
+    constexpr double TOL = 1e-7;
+    double ccelec = 332.0716;
+
+    // Setup parameters and reference values.
+    helpme::Matrix<double> coords(
+        {{2.0, 2.0, 2.0}, {2.5, 2.0, 3.0}, {1.5, 2.0, 3.0}, {0.0, 0.0, 0.0}, {0.5, 0.0, 1.0}, {-0.5, 0.0, 1.0}});
+    helpme::Matrix<double> charges({-0.834, 0.417, 0.417, -0.834, 0.417, 0.417});
+    short nfftx = 20;
+    short nffty = 21;
+    short nfftz = 22;
+    short splineOrder = 5;
+
+    double refEnergy1 = 5.8537004;
+    helpme::Matrix<double> refForces1({{0.60004038, 0.74129836, -6.31176591},
+                                       {-0.50238424, -0.44175023, 2.53478813},
+                                       {-0.34430074, -0.54474056, 2.60670541},
+                                       {1.14160970, 1.04857552, -5.07874657},
+                                       {-0.40743265, -0.45709529, 3.21032689},
+                                       {-0.48655356, -0.34618192, 3.03887422}
+
+    });
+    helpme::Matrix<double> refVirial1({{0.61893621, 0.49018413, 0.54959991, 2.29084071, 2.35776919, -9.96248284}});
+
+    double refEnergy2 = 5.855746495;
+    helpme::Matrix<double> refForces2({{0.60245163, 0.73942661, -6.31413552},
+                                       {-0.50396028, -0.44092114, 2.53631961},
+                                       {-0.34571162, -0.54380710, 2.60819278},
+                                       {1.14467175, 1.04727038, -5.08209801},
+                                       {-0.40871507, -0.45630372, 3.21165662},
+                                       {-0.48780357, -0.34545271, 3.04026873}});
+    helpme::Matrix<double> refVirial2({{0.61199705, 0.49055936, 0.54134312, 2.28222850, 2.36819958, -9.94504929}});
+
+    double refEnergy3 = 6.871736497;
+    helpme::Matrix<double> refForces3({{0.76684907, 0.94791216, -7.41216206},
+                                       {-0.61560181, -0.54001262, 2.95904725},
+                                       {-0.42875798, -0.68237489, 3.02853111},
+                                       {1.40351882, 1.29196455, -5.91724551},
+                                       {-0.52358846, -0.58722357, 3.77349856},
+                                       {-0.60098832, -0.43008731, 3.56873433}});
+    helpme::Matrix<double> refVirial3({{0.69619831, 0.55213933, 0.60823304, 2.78138346, 2.86610280, -11.39571070}});
+
+    double refEnergy4 = 6.8718135;
+    helpme::Matrix<double> refForces4({{0.76682663, 0.79604124, -7.42058381},
+                                       {-0.61559595, -0.45348406, 2.96384799},
+                                       {-0.42875295, -0.57298883, 3.03458962},
+                                       {1.40348529, 1.08508863, -5.92864929},
+                                       {-0.52356758, -0.49320229, 3.77867550},
+                                       {-0.60096417, -0.36124367, 3.57252549}});
+    helpme::Matrix<double> refVirial4({{0.69622261, 0.55220016, 0.60784358, 2.78135060, 2.86647846, -11.39584386}});
+    double refEnergy5 = 7.55899485;
+    helpme::Matrix<double> refForces5({{0.84350929, 0.87564537, -8.16264219},
+                                       {-0.67715554, -0.49883247, 3.26023278},
+                                       {-0.47162825, -0.63028771, 3.33804858},
+                                       {1.54383381, 1.19359749, -6.52151422},
+                                       {-0.57592433, -0.54252252, 4.15654305},
+                                       {-0.66106059, -0.39736803, 3.92977804}});
+    helpme::Matrix<double> refVirial5({{0.76584487, 0.60742018, 0.66862794, 3.05948566, 3.15312630, -12.53542824}});
+
+    double refEnergy6 = 7.558688228;
+    helpme::Matrix<double> refForces6({{0.84303319, 0.87557676, -8.16169899},
+                                       {-0.67691837, -0.49890558, 3.25971866},
+                                       {-0.47193007, -0.63032536, 3.33749220},
+                                       {1.54317624, 1.19339693, -6.52017613},
+                                       {-0.57607320, -0.54246197, 4.15560408},
+                                       {-0.66144590, -0.39732351, 3.92883941}});
+    helpme::Matrix<double> refVirial6({{0.76545755, 0.60761239, 0.66897556, 3.05912581, 3.15274330, -12.53308757}});
+
+    double refEnergy7 = 0.007626089169;
+    helpme::Matrix<double> refForces7({{0.00111343, 0.00115672, -0.00829002},
+                                       {-0.00081670, -0.00059903, 0.00320443},
+                                       {-0.00059187, -0.00079872, 0.00324183},
+                                       {0.00187292, 0.00145863, -0.00637289},
+                                       {-0.00076641, -0.00072244, 0.00423731},
+                                       {-0.00081164, -0.00049523, 0.00397890}});
+    helpme::Matrix<double> refVirial7({{0.00068085, 0.00059011, 0.00057443, 0.00357792, 0.00368895, -0.01097979}});
+
+    SECTION("EFV routines") {
+        double energy;
+        helpme::Matrix<double> forces(6, 3);
+        helpme::Matrix<double> virial(1, 6);
+
+        auto pme = std::unique_ptr<PMEInstanceD>(new PMEInstanceD);
+        pme->setup(1, 0.3, splineOrder, nfftx, nffty, nfftz, ccelec, 1);
+
+        // Start with random setup
+        forces.setZero();
+        virial.setZero();
+        pme->setLatticeVectors(21, 22, 20, 93, 92, 90, PMEInstanceD::LatticeType::XAligned);
+        energy = pme->computeEFVRec(0, charges, coords, forces, virial);
+        REQUIRE(energy == Approx(refEnergy1).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces1));
+        REQUIRE(virial.almostEquals(refVirial1));
+
+        // Call update with same parameters, to make sure everything's the same
+        forces.setZero();
+        virial.setZero();
+        pme->setLatticeVectors(21, 22, 20, 93, 92, 90, PMEInstanceD::LatticeType::XAligned);
+        energy = pme->computeEFVRec(0, charges, coords, forces, virial);
+        REQUIRE(energy == Approx(refEnergy1).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces1));
+        REQUIRE(virial.almostEquals(refVirial1));
+
+        // Now change the parameters, and make sure it updates correctly
+        forces.setZero();
+        virial.setZero();
+        pme->setLatticeVectors(21.5, 22.2, 20.1, 94, 91, 91, PMEInstanceD::LatticeType::XAligned);
+        energy = pme->computeEFVRec(0, charges, coords, forces, virial);
+        REQUIRE(energy == Approx(refEnergy2).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces2));
+        REQUIRE(virial.almostEquals(refVirial2));
+
+        // Back to the original setup
+        forces.setZero();
+        virial.setZero();
+        pme->setLatticeVectors(21, 22, 20, 93, 92, 90, PMEInstanceD::LatticeType::XAligned);
+        energy = pme->computeEFVRec(0, charges, coords, forces, virial);
+        REQUIRE(energy == Approx(refEnergy1).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces1));
+        REQUIRE(virial.almostEquals(refVirial1));
+
+        // Same, but new kappa value
+        forces.setZero();
+        virial.setZero();
+        pme->setup(1, 0.32, splineOrder, nfftx, nffty, nfftz, ccelec, 1);
+        energy = pme->computeEFVRec(0, charges, coords, forces, virial);
+        REQUIRE(energy == Approx(refEnergy3).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces3));
+        REQUIRE(virial.almostEquals(refVirial3));
+
+        // Adjust the grid slightly
+        forces.setZero();
+        virial.setZero();
+        pme->setup(1, 0.32, splineOrder, nfftx, nffty + 4, nfftz, ccelec, 1);
+        energy = pme->computeEFVRec(0, charges, coords, forces, virial);
+        REQUIRE(energy == Approx(refEnergy4).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces4));
+        REQUIRE(virial.almostEquals(refVirial4));
+
+        // Adjust the scale factor slightly
+        forces.setZero();
+        virial.setZero();
+        pme->setup(1, 0.32, splineOrder, nfftx, nffty + 4, nfftz, 1.1 * ccelec, 1);
+        energy = pme->computeEFVRec(0, charges, coords, forces, virial);
+        REQUIRE(energy == Approx(refEnergy5).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces5));
+        REQUIRE(virial.almostEquals(refVirial5));
+
+        // Adjust the scale factor slightly
+        forces.setZero();
+        virial.setZero();
+        pme->setup(1, 0.32, splineOrder + 1, nfftx, nffty + 4, nfftz, 1.1 * ccelec, 1);
+        energy = pme->computeEFVRec(0, charges, coords, forces, virial);
+        REQUIRE(energy == Approx(refEnergy6).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces6));
+        REQUIRE(virial.almostEquals(refVirial6));
+
+        // Change the physics from coulomb to some weird disperion
+        forces.setZero();
+        virial.setZero();
+        pme->setup(6, 0.32, splineOrder + 1, nfftx, nffty + 4, nfftz, 1.1 * ccelec, 1);
+        energy = pme->computeEFVRec(0, charges, coords, forces, virial);
+        REQUIRE(energy == Approx(refEnergy7).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces7));
+        REQUIRE(virial.almostEquals(refVirial7));
+    }
+
+    SECTION("EF routines") {
+        double energy;
+        helpme::Matrix<double> forces(6, 3);
+
+        auto pme = std::unique_ptr<PMEInstanceD>(new PMEInstanceD);
+        pme->setup(1, 0.3, splineOrder, nfftx, nffty, nfftz, ccelec, 1);
+
+        // Start with random setup
+        forces.setZero();
+        pme->setLatticeVectors(21, 22, 20, 93, 92, 90, PMEInstanceD::LatticeType::XAligned);
+        energy = pme->computeEFRec(0, charges, coords, forces);
+        REQUIRE(energy == Approx(refEnergy1).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces1));
+
+        // Call update with same parameters, to make sure everything's the same
+        forces.setZero();
+        pme->setLatticeVectors(21, 22, 20, 93, 92, 90, PMEInstanceD::LatticeType::XAligned);
+        energy = pme->computeEFRec(0, charges, coords, forces);
+        REQUIRE(energy == Approx(refEnergy1).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces1));
+
+        // Now change the parameters, and make sure it updates correctly
+        forces.setZero();
+        pme->setLatticeVectors(21.5, 22.2, 20.1, 94, 91, 91, PMEInstanceD::LatticeType::XAligned);
+        energy = pme->computeEFRec(0, charges, coords, forces);
+        REQUIRE(energy == Approx(refEnergy2).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces2));
+
+        // Back to the original setup
+        forces.setZero();
+        pme->setLatticeVectors(21, 22, 20, 93, 92, 90, PMEInstanceD::LatticeType::XAligned);
+        energy = pme->computeEFRec(0, charges, coords, forces);
+        REQUIRE(energy == Approx(refEnergy1).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces1));
+
+        // Same, but new kappa value
+        forces.setZero();
+        pme->setup(1, 0.32, splineOrder, nfftx, nffty, nfftz, ccelec, 1);
+        energy = pme->computeEFRec(0, charges, coords, forces);
+        REQUIRE(energy == Approx(refEnergy3).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces3));
+
+        // Adjust the grid slightly
+        forces.setZero();
+        pme->setup(1, 0.32, splineOrder, nfftx, nffty + 4, nfftz, ccelec, 1);
+        energy = pme->computeEFRec(0, charges, coords, forces);
+        REQUIRE(energy == Approx(refEnergy4).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces4));
+
+        // Adjust the scale factor slightly
+        forces.setZero();
+        pme->setup(1, 0.32, splineOrder, nfftx, nffty + 4, nfftz, 1.1 * ccelec, 1);
+        energy = pme->computeEFRec(0, charges, coords, forces);
+        REQUIRE(energy == Approx(refEnergy5).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces5));
+
+        // Adjust the scale factor slightly
+        forces.setZero();
+        pme->setup(1, 0.32, splineOrder + 1, nfftx, nffty + 4, nfftz, 1.1 * ccelec, 1);
+        energy = pme->computeEFRec(0, charges, coords, forces);
+        REQUIRE(energy == Approx(refEnergy6).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces6));
+
+        // Change the physics from coulomb to some weird disperion
+        forces.setZero();
+        pme->setup(6, 0.32, splineOrder + 1, nfftx, nffty + 4, nfftz, 1.1 * ccelec, 1);
+        energy = pme->computeEFRec(0, charges, coords, forces);
+        REQUIRE(energy == Approx(refEnergy7).margin(TOL));
+        REQUIRE(forces.almostEquals(refForces7));
+    }
+
+    SECTION("E routines") {
+        double energy;
+
+        auto pme = std::unique_ptr<PMEInstanceD>(new PMEInstanceD);
+        pme->setup(1, 0.3, splineOrder, nfftx, nffty, nfftz, ccelec, 1);
+
+        // Start with random setup
+        pme->setLatticeVectors(21, 22, 20, 93, 92, 90, PMEInstanceD::LatticeType::XAligned);
+        energy = pme->computeERec(0, charges, coords);
+        REQUIRE(energy == Approx(refEnergy1).margin(TOL));
+
+        // Call update with same parameters, to make sure everything's the same
+        pme->setLatticeVectors(21, 22, 20, 93, 92, 90, PMEInstanceD::LatticeType::XAligned);
+        energy = pme->computeERec(0, charges, coords);
+        REQUIRE(energy == Approx(refEnergy1).margin(TOL));
+
+        // Now change the parameters, and make sure it updates correctly
+        pme->setLatticeVectors(21.5, 22.2, 20.1, 94, 91, 91, PMEInstanceD::LatticeType::XAligned);
+        energy = pme->computeERec(0, charges, coords);
+        REQUIRE(energy == Approx(refEnergy2).margin(TOL));
+
+        // Back to the original setup
+        pme->setLatticeVectors(21, 22, 20, 93, 92, 90, PMEInstanceD::LatticeType::XAligned);
+        energy = pme->computeERec(0, charges, coords);
+        REQUIRE(energy == Approx(refEnergy1).margin(TOL));
+
+        // Same, but new kappa value
+        pme->setup(1, 0.32, splineOrder, nfftx, nffty, nfftz, ccelec, 1);
+        energy = pme->computeERec(0, charges, coords);
+        REQUIRE(energy == Approx(refEnergy3).margin(TOL));
+
+        // Adjust the grid slightly
+        pme->setup(1, 0.32, splineOrder, nfftx, nffty + 4, nfftz, ccelec, 1);
+        energy = pme->computeERec(0, charges, coords);
+        REQUIRE(energy == Approx(refEnergy4).margin(TOL));
+
+        // Adjust the scale factor slightly
+        pme->setup(1, 0.32, splineOrder, nfftx, nffty + 4, nfftz, 1.1 * ccelec, 1);
+        energy = pme->computeERec(0, charges, coords);
+        REQUIRE(energy == Approx(refEnergy5).margin(TOL));
+
+        // Adjust the scale factor slightly
+        pme->setup(1, 0.32, splineOrder + 1, nfftx, nffty + 4, nfftz, 1.1 * ccelec, 1);
+        energy = pme->computeERec(0, charges, coords);
+        REQUIRE(energy == Approx(refEnergy6).margin(TOL));
+
+        // Change the physics from coulomb to some weird disperion
+        pme->setup(6, 0.32, splineOrder + 1, nfftx, nffty + 4, nfftz, 1.1 * ccelec, 1);
+        energy = pme->computeERec(0, charges, coords);
+        REQUIRE(energy == Approx(refEnergy7).margin(TOL));
+    }
+}

--- a/tools/check_style.sh
+++ b/tools/check_style.sh
@@ -50,7 +50,7 @@ do
                 echo "****************************************************"
                 echo "Formatting problem detected.  Run"
                 echo
-                echo "clang-format --style=file -i $file"
+                echo "${CLANGFORMAT} --style=file -i $file"
                 echo
                 echo "from the top directory, or apply the following diff:"
                 echo "----------------------------------------------------"


### PR DESCRIPTION
The influence function can be quite expensive to compute; this PR adds the capability to store it, recomputing only when kappa or cell dimensions, upon which it depends, change.