### PR TITLE
Remove BLAS/Lapack dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,6 @@ cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
 #    - CMAKE_Fortran_COMPILER "Fortran compiler (required for some add-ons)"
 #    - CMAKE_Fortran_FLAGS "Additional Fortran flags"
 #
-#  <<<  Detecting BLAS/LAPACK  >>>
-#
-#    - ENV(MATH_ROOT) "Root directory where BLAS/LAPACK libraries should be detected (e.g., ${MATH_ROOT}/lib/libblas.so)"
-#
 #  <<<  Detecting dependencies and add-ons  >>>
 #
 #    - PYTHON_EXECUTABLE "Python interpreter to use (e.g., /path/to/bin/python2.7)"
@@ -70,16 +66,10 @@ option_with_flags(ENABLE_TSAN "Enables thread sanitizer" OFF
                   "-fsanitize=thread" "-fno-omit-frame-pointer -pie")
 option_with_flags(ENABLE_UBSAN "Enables undefined behavior sanitizer" OFF
                   "-fsanitize=undefined" "-fno-omit-frame-pointer")
-option_with_default(FC_SYMBOL "The type of Fortran name mangling" 2)
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")
 set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -O0")
-
-# Linear algebra stuff is needed
-find_package(BLAS REQUIRED)
-find_package(LAPACK REQUIRED)
-add_definitions("-DFC_SYMBOL=${FC_SYMBOL}")
 
 # FFTW
 find_package(FFTW REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,16 @@ set(Python_ENABLED ON) # For now, we just always assume this is on
 add_subdirectory(external/pybind11)
 add_subdirectory(python)
 
+# Handle different C++ libraries
+if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+    set(cpplib c++)
+else()
+    set(cpplib stdc++)
+endif()
+
+# The C++ library is linked explicitly because exception handling on macOS appears to be broken otherwise.
+set(EXTERNAL_LIBRARIES ${FFTW_LIBRARIES} ${cpplib})
+
 # Documentation
 find_package(Doxygen)
 find_package(Sphinx)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -18,7 +18,7 @@ add_custom_target(PythonInstall
 
 include_directories(../src)
 include_directories(${FFTW_INCLUDES})
-link_libraries(${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${FFTW_LIBRARIES})
+link_libraries(${FFTW_LIBRARIES})
 pybind11_add_module(helpmelib pywrappers.cc)
 
 configure_file(setup.py . COPYONLY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ set(sources_list
 
 include_directories(${FFTW_INCLUDES})
 add_library(helpmestatic STATIC ${sources_list})
+target_link_libraries(helpmestatic ${FFTW_LIBRARIES})
 
 if(Fortran_ENABLED AND CMAKE_Fortran_COMPILER_ID MATCHES Intel)
     #Enable call to for_rtl_init_() which is required if using the

--- a/src/helpme.h
+++ b/src/helpme.h
@@ -1058,10 +1058,7 @@ class PMEInstance {
 
                 auto eigenTuple = HtH.diagonalize();
                 RealMat evalsReal = std::get<0>(eigenTuple);
-                RealMat evalsImag = std::get<1>(eigenTuple);
-                RealMat evecs = std::get<2>(eigenTuple);
-                if (!evalsImag.isNearZero())
-                    throw std::runtime_error("Unexpected complex eigenvalues encountered while making shape matrix.");
+                RealMat evecs = std::get<1>(eigenTuple);
                 for (int i = 0; i < 3; ++i) evalsReal(i, 0) = sqrt(evalsReal(i, 0));
                 boxVecs_.setZero();
                 for (int i = 0; i < 3; ++i) {

--- a/src/lapack_wrapper.h
+++ b/src/lapack_wrapper.h
@@ -6,115 +6,231 @@
 // Author: Andrew C. Simmonett
 //
 // ENDLICENSE
+//
+// The code for Jacobi diagonalization is taken (with minimal modification) from
+//
+// http://www.mymathlib.com/c_source/matrices/eigen/jacobi_cyclic_method.c
+//
 #ifndef _HELPME_LAPACK_WRAPPER_H_
 #define _HELPME_LAPACK_WRAPPER_H_
 
-#include <exception>
-#include <functional>
-#include <complex>
-
-#if FC_SYMBOL == 2
-#define F_SGEEV sgeev_
-#define F_SGESV sgesv_
-#define F_DGEEV dgeev_
-#define F_DGESV dgesv_
-#define F_CGEEV cgeev_
-#define F_CGESV cgesv_
-#define F_ZGEEV zgeev_
-#define F_ZGESV zgesv_
-#elif FC_SYMBOL == 1
-#define F_SGEEV sgeev
-#define F_SGESV sgesv
-#define F_DGEEV dgeev
-#define F_DGESV dgesv
-#define F_CGEEV cgeev
-#define F_CGESV cgesv
-#define F_ZGEEV zgeev
-#define F_ZGESV zgesv
-#elif FC_SYMBOL == 3
-#define F_SGEEV SGEEV
-#define F_SGESV SGESV
-#define F_DGEEV DGEEV
-#define F_DGESV DGESV
-#define F_CGEEV CGEEV
-#define F_CGESV CGESV
-#define F_ZGEEV ZGEEV
-#define F_ZGESV ZGESV
-#elif FC_SYMBOL == 4
-#define F_SGEEV SGEEV_
-#define F_SGESV SGESV_
-#define F_DGEEV DGEEV_
-#define F_DGESV DGESV_
-#define F_CGEEV CGEEV_
-#define F_CGESV CGESV_
-#define F_ZGEEV ZGEEV_
-#define F_ZGESV ZGESV_
-#endif
-
-extern "C" {
-extern void F_SGEEV(char *, char *, int *, float *, int *, float *, float *, float *, int *, float *, int *, float *,
-                    int *, int *);
-extern void F_DGEEV(char *, char *, int *, double *, int *, double *, double *, double *, int *, double *, int *,
-                    double *, int *, int *);
-extern void F_CGEEV(char *, char *, int *, std::complex<float> *, int *, std::complex<float> *, std::complex<float> *,
-                    std::complex<float> *, int *, std::complex<float> *, int *, std::complex<float> *, int *, int *);
-extern void F_ZGEEV(char *, char *, int *, std::complex<double> *, int *, std::complex<double> *,
-                    std::complex<double> *, std::complex<double> *, int *, std::complex<double> *, int *,
-                    std::complex<double> *, int *, int *);
-}
+#include <cmath>
+#include <limits>
 
 namespace helpme {
-
-static void C_SGEEV(char jobvl, char jobvr, int n, float *a, int lda, float *wr, float *wi, float *vl, int ldvl,
-                    float *vr, int ldvr, float *work, int lwork, int *info) {
-    ::F_SGEEV(&jobvl, &jobvr, &n, a, &lda, wr, wi, vl, &ldvl, vr, &ldvr, work, &lwork, info);
-}
-
-static void C_DGEEV(char jobvl, char jobvr, int n, double *a, int lda, double *wr, double *wi, double *vl, int ldvl,
-                    double *vr, int ldvr, double *work, int lwork, int *info) {
-    ::F_DGEEV(&jobvl, &jobvr, &n, a, &lda, wr, wi, vl, &ldvl, vr, &ldvr, work, &lwork, info);
-}
-
-static void C_CGEEV(char jobvl, char jobvr, int n, std::complex<float> *a, int lda, std::complex<float> *wr,
-                    std::complex<float> *wi, std::complex<float> *vl, int ldvl, std::complex<float> *vr, int ldvr,
-                    std::complex<float> *work, int lwork, int *info) {
-    ::F_CGEEV(&jobvl, &jobvr, &n, a, &lda, wr, wi, vl, &ldvl, vr, &ldvr, work, &lwork, info);
-}
-
-static void C_ZGEEV(char jobvl, char jobvr, int n, std::complex<double> *a, int lda, std::complex<double> *wr,
-                    std::complex<double> *wi, std::complex<double> *vl, int ldvl, std::complex<double> *vr, int ldvr,
-                    std::complex<double> *work, int lwork, int *info) {
-    ::F_ZGEEV(&jobvl, &jobvr, &n, a, &lda, wr, wi, vl, &ldvl, vr, &ldvr, work, &lwork, info);
-}
+////////////////////////////////////////////////////////////////////////////////
+//  void Jacobi_Cyclic_Method                                                 //
+//            (Real eigenvalues[], Real *eigenvectors, Real *A, int n)  //
+//                                                                            //
+//  Description:                                                              //
+//     Find the eigenvalues and eigenvectors of a symmetric n x n matrix A    //
+//     using the Jacobi method. Upon return, the input matrix A will have     //
+//     been modified.                                                         //
+//     The Jacobi procedure for finding the eigenvalues and eigenvectors of a //
+//     symmetric matrix A is based on finding a similarity transformation     //
+//     which diagonalizes A.  The similarity transformation is given by a     //
+//     product of a sequence of orthogonal (rotation) matrices each of which  //
+//     annihilates an off-diagonal element and its transpose.  The rotation   //
+//     effects only the rows and columns containing the off-diagonal element  //
+//     and its transpose, i.e. if a[i][j] is an off-diagonal element, then    //
+//     the orthogonal transformation rotates rows a[i][] and a[j][], and      //
+//     equivalently it rotates columns a[][i] and a[][j], so that a[i][j] = 0 //
+//     and a[j][i] = 0.                                                       //
+//     The cyclic Jacobi method considers the off-diagonal elements in the    //
+//     following order: (0,1),(0,2),...,(0,n-1),(1,2),...,(n-2,n-1).  If the  //
+//     the magnitude of the off-diagonal element is greater than a treshold,  //
+//     then a rotation is performed to annihilate that off-diagnonal element. //
+//     The process described above is called a sweep.  After a sweep has been //
+//     completed, the threshold is lowered and another sweep is performed     //
+//     with the new threshold. This process is completed until the final      //
+//     sweep is performed with the final threshold.                           //
+//     The orthogonal transformation which annihilates the matrix element     //
+//     a[k][m], k != m, is Q = q[i][j], where q[i][j] = 0 if i != j, i,j != k //
+//     i,j != m and q[i][j] = 1 if i = j, i,j != k, i,j != m, q[k][k] =       //
+//     q[m][m] = cos(phi), q[k][m] = -sin(phi), and q[m][k] = sin(phi), where //
+//     the angle phi is determined by requiring a[k][m] -> 0.  This condition //
+//     on the angle phi is equivalent to                                      //
+//               cot(2 phi) = 0.5 * (a[k][k] - a[m][m]) / a[k][m]             //
+//     Since tan(2 phi) = 2 tan(phi) / (1 - tan(phi)^2),                      //
+//               tan(phi)^2 + 2cot(2 phi) * tan(phi) - 1 = 0.                 //
+//     Solving for tan(phi), choosing the solution with smallest magnitude,   //
+//       tan(phi) = - cot(2 phi) + sgn(cot(2 phi)) sqrt(cot(2phi)^2 + 1).     //
+//     Then cos(phi)^2 = 1 / (1 + tan(phi)^2) and sin(phi)^2 = 1 - cos(phi)^2 //
+//     Finally by taking the sqrts and assigning the sign to the sin the same //
+//     as that of the tan, the orthogonal transformation Q is determined.     //
+//     Let A" be the matrix obtained from the matrix A by applying the        //
+//     similarity transformation Q, since Q is orthogonal, A" = Q'AQ, where Q'//
+//     is the transpose of Q (which is the same as the inverse of Q).  Then   //
+//         a"[i][j] = Q'[i][p] a[p][q] Q[q][j] = Q[p][i] a[p][q] Q[q][j],     //
+//     where repeated indices are summed over.                                //
+//     If i is not equal to either k or m, then Q[i][j] is the Kronecker      //
+//     delta.   So if both i and j are not equal to either k or m,            //
+//                                a"[i][j] = a[i][j].                         //
+//     If i = k, j = k,                                                       //
+//        a"[k][k] =                                                          //
+//           a[k][k]*cos(phi)^2 + a[k][m]*sin(2 phi) + a[m][m]*sin(phi)^2     //
+//     If i = k, j = m,                                                       //
+//        a"[k][m] = a"[m][k] = 0 =                                           //
+//           a[k][m]*cos(2 phi) + 0.5 * (a[m][m] - a[k][k])*sin(2 phi)        //
+//     If i = k, j != k or m,                                                 //
+//        a"[k][j] = a"[j][k] = a[k][j] * cos(phi) + a[m][j] * sin(phi)       //
+//     If i = m, j = k, a"[m][k] = 0                                          //
+//     If i = m, j = m,                                                       //
+//        a"[m][m] =                                                          //
+//           a[m][m]*cos(phi)^2 - a[k][m]*sin(2 phi) + a[k][k]*sin(phi)^2     //
+//     If i= m, j != k or m,                                                  //
+//        a"[m][j] = a"[j][m] = a[m][j] * cos(phi) - a[k][j] * sin(phi)       //
+//                                                                            //
+//     If X is the matrix of normalized eigenvectors stored so that the ith   //
+//     column corresponds to the ith eigenvalue, then AX = X Lamda, where     //
+//     Lambda is the diagonal matrix with the ith eigenvalue stored at        //
+//     Lambda[i][i], i.e. X'AX = Lambda and X is orthogonal, the eigenvectors //
+//     are normalized and orthogonal.  So, X = Q1 Q2 ... Qs, where Qi is      //
+//     the ith orthogonal matrix,  i.e. X can be recursively approximated by  //
+//     the recursion relation X" = X Q, where Q is the orthogonal matrix and  //
+//     the initial estimate for X is the identity matrix.                     //
+//     If j = k, then x"[i][k] = x[i][k] * cos(phi) + x[i][m] * sin(phi),     //
+//     if j = m, then x"[i][m] = x[i][m] * cos(phi) - x[i][k] * sin(phi), and //
+//     if j != k and j != m, then x"[i][j] = x[i][j].                         //
+//                                                                            //
+//  Arguments:                                                                //
+//     Real  eigenvalues                                                      //
+//        Array of dimension n, which upon return contains the eigenvalues of //
+//        the matrix A.                                                       //
+//     Real* eigenvectors                                                     //
+//        Matrix of eigenvectors, the ith column of which contains an         //
+//        eigenvector corresponding to the ith eigenvalue in the array        //
+//        eigenvalues.                                                        //
+//     Real* A                                                                //
+//        Pointer to the first element of the symmetric n x n matrix A. The   //
+//        input matrix A is modified during the process.                      //
+//     int     n                                                              //
+//        The dimension of the array eigenvalues, number of columns and rows  //
+//        of the matrices eigenvectors and A.                                 //
+//                                                                            //
+//  Return Values:                                                            //
+//     Function is of type void.                                              //
+//                                                                            //
+//  Example:                                                                  //
+//     #define N                                                              //
+//     Real A[N][N], Real eigenvalues[N], Real eigenvectors[N][N]             //
+//                                                                            //
+//     (your code to initialize the matrix A )                                //
+//                                                                            //
+//     JacobiCyclicDiagonalization(eigenvalues, (Real*)eigenvectors,          //
+//                                                          (Real *) A, N);   //
+////////////////////////////////////////////////////////////////////////////////
 
 template <typename Real>
-using diagonalizerType =
-    std::function<void(char, char, int, Real *, int, Real *, Real *, Real *, int, Real *, int, Real *, int, int *)>;
+void JacobiCyclicDiagonalization(Real *eigenvalues, Real *eigenvectors, const Real *A, int n) {
+    int row, i, j, k, m;
+    Real *pAk, *pAm, *p_r, *p_e;
+    Real threshold_norm;
+    Real threshold;
+    Real tan_phi, sin_phi, cos_phi, tan2_phi, sin2_phi, cos2_phi;
+    Real sin_2phi, cos_2phi, cot_2phi;
+    Real dum1;
+    Real dum2;
+    Real dum3;
+    Real r;
+    Real max;
 
-template <typename Real>
-class LapackWrapper {
-   public:
-    static diagonalizerType<Real> diagonalizer() {
-        throw std::runtime_error("Diagonalization is not implemented for the requested data type");
-        return diagonalizerType<Real>();
+    // Take care of trivial cases
+
+    if (n < 1) return;
+    if (n == 1) {
+        eigenvalues[0] = *A;
+        *eigenvectors = 1;
+        return;
     }
-};
 
-template <>
-inline diagonalizerType<float> LapackWrapper<float>::diagonalizer() {
-    return &C_SGEEV;
-}
-template <>
-inline diagonalizerType<double> LapackWrapper<double>::diagonalizer() {
-    return &C_DGEEV;
-}
-template <>
-inline diagonalizerType<std::complex<float>> LapackWrapper<std::complex<float>>::diagonalizer() {
-    return &C_CGEEV;
-}
-template <>
-inline diagonalizerType<std::complex<double>> LapackWrapper<std::complex<double>>::diagonalizer() {
-    return &C_ZGEEV;
+    // Initialize the eigenvalues to the identity matrix.
+
+    for (p_e = eigenvectors, i = 0; i < n; i++)
+        for (j = 0; j < n; p_e++, j++)
+            if (i == j)
+                *p_e = 1;
+            else
+                *p_e = 0;
+
+    // Calculate the threshold and threshold_norm.
+
+    for (threshold = 0, pAk = const_cast<Real *>(A), i = 0; i < (n - 1); pAk += n, i++)
+        for (j = i + 1; j < n; j++) threshold += *(pAk + j) * *(pAk + j);
+    threshold = sqrt(threshold + threshold);
+    threshold_norm = threshold * std::numeric_limits<Real>::epsilon();
+    max = threshold + 1;
+    while (threshold > threshold_norm) {
+        threshold /= 10;
+        if (max < threshold) continue;
+        max = 0;
+        for (pAk = const_cast<Real *>(A), k = 0; k < (n - 1); pAk += n, k++) {
+            for (pAm = pAk + n, m = k + 1; m < n; pAm += n, m++) {
+                if (std::abs(*(pAk + m)) < threshold) continue;
+
+                // Calculate the sin and cos of the rotation angle which
+                // annihilates A[k][m].
+
+                cot_2phi = 0.5f * (*(pAk + k) - *(pAm + m)) / *(pAk + m);
+                dum1 = sqrt(cot_2phi * cot_2phi + 1);
+                if (cot_2phi < 0) dum1 = -dum1;
+                tan_phi = -cot_2phi + dum1;
+                tan2_phi = tan_phi * tan_phi;
+                sin2_phi = tan2_phi / (1 + tan2_phi);
+                cos2_phi = 1 - sin2_phi;
+                sin_phi = sqrt(sin2_phi);
+                if (tan_phi < 0) sin_phi = -sin_phi;
+                cos_phi = sqrt(cos2_phi);
+                sin_2phi = 2 * sin_phi * cos_phi;
+                cos_2phi = cos2_phi - sin2_phi;
+
+                // Rotate columns k and m for both the matrix A
+                //     and the matrix of eigenvectors.
+
+                p_r = const_cast<Real *>(A);
+                dum1 = *(pAk + k);
+                dum2 = *(pAm + m);
+                dum3 = *(pAk + m);
+                *(pAk + k) = dum1 * cos2_phi + dum2 * sin2_phi + dum3 * sin_2phi;
+                *(pAm + m) = dum1 * sin2_phi + dum2 * cos2_phi - dum3 * sin_2phi;
+                *(pAk + m) = 0;
+                *(pAm + k) = 0;
+                for (i = 0; i < n; p_r += n, i++) {
+                    if ((i == k) || (i == m)) continue;
+                    if (i < k)
+                        dum1 = *(p_r + k);
+                    else
+                        dum1 = *(pAk + i);
+                    if (i < m)
+                        dum2 = *(p_r + m);
+                    else
+                        dum2 = *(pAm + i);
+                    dum3 = dum1 * cos_phi + dum2 * sin_phi;
+                    if (i < k)
+                        *(p_r + k) = dum3;
+                    else
+                        *(pAk + i) = dum3;
+                    dum3 = -dum1 * sin_phi + dum2 * cos_phi;
+                    if (i < m)
+                        *(p_r + m) = dum3;
+                    else
+                        *(pAm + i) = dum3;
+                }
+                for (p_e = eigenvectors, i = 0; i < n; p_e += n, i++) {
+                    dum1 = *(p_e + k);
+                    dum2 = *(p_e + m);
+                    *(p_e + k) = dum1 * cos_phi + dum2 * sin_phi;
+                    *(p_e + m) = -dum1 * sin_phi + dum2 * cos_phi;
+                }
+            }
+            for (i = 0; i < n; i++)
+                if (i == k)
+                    continue;
+                else if (max < std::abs(*(pAk + i)))
+                    max = std::abs(*(pAk + i));
+        }
+    }
+    for (pAk = const_cast<Real *>(A), k = 0; k < n; pAk += n, k++) eigenvalues[k] = *(pAk + k);
 }
 
 }  // Namespace helpme

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,12 +41,6 @@ add_custom_target(SingleHeader
                   DEPENDS StandaloneHeader
 )
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
-    set(cpplib c++)
-else()
-    set(cpplib stdc++)
-endif()
-
 # C example
 add_executable (RunCWrapper fullexample.c)
 add_dependencies(RunCWrapper helpmestatic)
@@ -56,20 +50,20 @@ add_test(NAME CWrapperTest COMMAND RunCWrapper)
 
 # CXX DHFR benchmark example
 add_executable (DHFRBenchmark dhfr_benchmark.cpp)
-target_link_libraries(DHFRBenchmark ${FFTW_LIBRARIES})
+target_link_libraries(DHFRBenchmark ${EXTERNAL_LIBRARIES})
 configure_file(data/dhfr_charges.txt . COPYONLY)
 configure_file(data/dhfr_c6s.txt . COPYONLY)
 configure_file(data/dhfr_coords.txt . COPYONLY)
 
 # CXX example
 add_executable (RunCXXWrapper fullexample.cpp)
-target_link_libraries(RunCXXWrapper ${FFTW_LIBRARIES})
+target_link_libraries(RunCXXWrapper ${EXTERNAL_LIBRARIES})
 add_test(NAME CXXWrapperTest COMMAND RunCXXWrapper)
 
 # CXX example using standalone header file
 add_executable (RunCXXWrapperStandalone fullexample.cpp)
 add_dependencies(RunCXXWrapperStandalone SingleHeader)
-target_link_libraries(RunCXXWrapperStandalone ${FFTW_LIBRARIES})
+target_link_libraries(RunCXXWrapperStandalone ${EXTERNAL_LIBRARIES})
 target_compile_definitions(RunCXXWrapperStandalone PRIVATE "BUILD_STANDALONE=1")
 add_test(NAME CXXWrapperStandaloneTest COMMAND RunCXXWrapperStandalone)
 
@@ -77,7 +71,7 @@ add_test(NAME CXXWrapperStandaloneTest COMMAND RunCXXWrapperStandalone)
 if(HAVE_MPI)
     # CXX example
     add_executable (RunCXXMPIWrapper fullexample_parallel.cpp)
-    target_link_libraries(RunCXXMPIWrapper ${FFTW_LIBRARIES})
+    target_link_libraries(RunCXXMPIWrapper ${EXTERNAL_LIBRARIES})
     add_test(NAME CXXMPIWrapperTestX
              COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} ./RunCXXMPIWrapper 2 1 1 ${MPIEXEC_POSTFLAGS})
     add_test(NAME CXXMPIWrapperTestY

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,7 +23,6 @@ endforeach()
 include_directories(${PROJECT_SOURCE_DIR}/src)
 include_directories(${PROJECT_SOURCE_DIR}/single_include)
 include_directories(${FFTW_INCLUDES})
-link_libraries(${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${FFTW_LIBRARIES})
 
 if(HAVE_MPI)
     link_libraries(${MPI_CXX_LIBRARIES})
@@ -42,30 +41,35 @@ add_custom_target(SingleHeader
                   DEPENDS StandaloneHeader
 )
 
-# Find only the static library for linking with C++/C/Fortran wrappers
-set(helpmestatic_name ${CMAKE_BINARY_DIR}/src/helpme.a)
+if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+    set(cpplib c++)
+else()
+    set(cpplib stdc++)
+endif()
 
 # C example
 add_executable (RunCWrapper fullexample.c)
 add_dependencies(RunCWrapper helpmestatic)
-target_link_libraries(RunCWrapper ${helpmestatic_name})
+target_link_libraries(RunCWrapper helpmestatic)
 set_target_properties(RunCWrapper PROPERTIES LINKER_LANGUAGE CXX)
 add_test(NAME CWrapperTest COMMAND RunCWrapper)
 
 # CXX DHFR benchmark example
 add_executable (DHFRBenchmark dhfr_benchmark.cpp)
+target_link_libraries(DHFRBenchmark ${FFTW_LIBRARIES})
 configure_file(data/dhfr_charges.txt . COPYONLY)
 configure_file(data/dhfr_c6s.txt . COPYONLY)
 configure_file(data/dhfr_coords.txt . COPYONLY)
-#target_compile_options(DHFRBenchmark  PRIVATE -g)
 
 # CXX example
 add_executable (RunCXXWrapper fullexample.cpp)
+target_link_libraries(RunCXXWrapper ${FFTW_LIBRARIES})
 add_test(NAME CXXWrapperTest COMMAND RunCXXWrapper)
 
 # CXX example using standalone header file
 add_executable (RunCXXWrapperStandalone fullexample.cpp)
 add_dependencies(RunCXXWrapperStandalone SingleHeader)
+target_link_libraries(RunCXXWrapperStandalone ${FFTW_LIBRARIES})
 target_compile_definitions(RunCXXWrapperStandalone PRIVATE "BUILD_STANDALONE=1")
 add_test(NAME CXXWrapperStandaloneTest COMMAND RunCXXWrapperStandalone)
 
@@ -73,6 +77,7 @@ add_test(NAME CXXWrapperStandaloneTest COMMAND RunCXXWrapperStandalone)
 if(HAVE_MPI)
     # CXX example
     add_executable (RunCXXMPIWrapper fullexample_parallel.cpp)
+    target_link_libraries(RunCXXMPIWrapper ${FFTW_LIBRARIES})
     add_test(NAME CXXMPIWrapperTestX
              COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} ./RunCXXMPIWrapper 2 1 1 ${MPIEXEC_POSTFLAGS})
     add_test(NAME CXXMPIWrapperTestY
@@ -82,8 +87,7 @@ if(HAVE_MPI)
 
     # C example
     add_executable (RunCMPIWrapper fullexample_parallel.c)
-    add_dependencies(RunCMPIWrapper helpmestatic)
-    target_link_libraries(RunCMPIWrapper ${helpmestatic_name})
+    target_link_libraries(RunCMPIWrapper helpmestatic)
     set_target_properties(RunCMPIWrapper PROPERTIES LINKER_LANGUAGE CXX)
     add_test(NAME CMPIWrapperTestX
              COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} ./RunCMPIWrapper 2 1 1 ${MPIEXEC_POSTFLAGS})
@@ -96,13 +100,8 @@ if(HAVE_MPI)
     if(Fortran_ENABLED)
         link_libraries(${MPI_Fortran_LIBRARIES})
         add_executable(RunFortranMPIWrapper ${PROJECT_SOURCE_DIR}/src/helpme.F90 fullexample_parallel.F90 )
-        add_dependencies(RunFortranMPIWrapper helpmestatic)
-        if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
-            set(cpplib c++)
-        else()
-            set(cpplib stdc++)
-        endif()
-        target_link_libraries(RunFortranMPIWrapper ${helpmestatic_name} ${cpplib})
+        set_target_properties(RunFortranMPIWrapper PROPERTIES LINKER_LANGUAGE Fortran)
+        target_link_libraries(RunFortranMPIWrapper helpmestatic ${cpplib})
         add_test(NAME FortranMPIWrapperTestX
                  COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} ./RunFortranMPIWrapper 2 1 1 ${MPIEXEC_POSTFLAGS})
         add_test(NAME FortranMPIWrapperTestY
@@ -115,13 +114,8 @@ endif()
 # Fortran example
 if(Fortran_ENABLED)
     add_executable(RunFortranWrapper ${PROJECT_SOURCE_DIR}/src/helpme.F90 fullexample.F90 )
-    add_dependencies(RunFortranWrapper helpmestatic)
-    if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
-        set(cpplib c++)
-    else()
-        set(cpplib stdc++)
-    endif()
-    target_link_libraries(RunFortranWrapper ${helpmestatic_name} ${cpplib})
+    target_link_libraries(RunFortranWrapper helpmestatic ${cpplib})
+    set_target_properties(RunFortranWrapper PROPERTIES LINKER_LANGUAGE Fortran)
     add_test(NAME FortranWrapper COMMAND RunFortranWrapper)
 endif()
 
@@ -132,3 +126,4 @@ if(Python_ENABLED)
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../python
     )
 endif()
+

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -75,7 +75,7 @@ add_library( CatchMain OBJECT ${UNITTEST_DIR}/${SOURCES_UNITTESTS_MAIN} ${HEADER
 foreach( name ${TARGETS_UNITTESTS_PARALLEL_TESTS} )
     add_executable( ${name} ${name}.cpp $<TARGET_OBJECTS:CatchMain> ${HEADER_DIR}/catch.hpp )
     set_target_properties(${name} PROPERTIES COMPILE_FLAGS "${MPI_CXX_COMPILE_FLAGS}")
-    target_link_libraries( ${name} PRIVATE ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${FFTW_LIBRARIES} ${MPI_CXX_LIBRARIES})
+    target_link_libraries( ${name} PRIVATE ${EXTERNAL_LIBRARIES} ${MPI_CXX_LIBRARIES})
     target_compile_definitions(${name} PRIVATE "-DHAVE_MPI=1")
     target_include_directories(${name} PRIVATE "${MPI_CXX_INCLUDE_PATH}")
     add_test(NAME ${name}
@@ -85,7 +85,7 @@ endforeach()
 
 foreach( name ${TARGETS_UNITTESTS_TESTS} )
     add_executable( ${name} ${name}.cpp $<TARGET_OBJECTS:CatchMain> ${HEADER_DIR}/catch.hpp )
-    target_link_libraries( ${name} PRIVATE ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES} ${FFTW_LIBRARIES})
+    target_link_libraries( ${name} PRIVATE ${EXTERNAL_LIBRARIES})
     add_test(NAME ${name}
              COMMAND ${name} 
              WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test/unittests)

--- a/test/unittests/unittest-matrix.cpp
+++ b/test/unittests/unittest-matrix.cpp
@@ -154,28 +154,24 @@ TEST_CASE("test the matrix class.") {
     }
 
     SECTION("Diagonalization. ") {
-        helpme::Matrix<double> mat({{12, 2, 0}, {1, 11, 0}, {2, 4, 15}});
-        SECTION("Ascending order ") {
-            helpme::Matrix<double> refEvecsA({{-0.6804138174, 0.4364357805, 0.0},
-                                              {0.6804138174, 0.2182178902, 0.0},
-                                              {-0.2721655270, -0.8728715609, 1.0}});
-            helpme::Matrix<double> refEvalsRealA({10, 13, 15});
-            helpme::Matrix<double> refEvalsImagA(3, 1);
-            auto eigensystemA = mat.diagonalize();
-            REQUIRE(refEvalsRealA.almostEquals(std::get<0>(eigensystemA)));
-            REQUIRE(refEvalsImagA.almostEquals(std::get<1>(eigensystemA)));
-            REQUIRE(refEvecsA.almostEquals(std::get<2>(eigensystemA)));
-        }
+        helpme::Matrix<double> mat({{12, 2, 1}, {2, 11, 4}, {1, 4, 15}});
         SECTION("Descending order ") {
-            helpme::Matrix<double> refEvecsD({{0.0, 0.4364357805, -0.6804138174},
-                                              {0.0, 0.2182178902, 0.6804138174},
-                                              {1.0, -0.8728715609, -0.2721655270}});
-            helpme::Matrix<double> refEvalsRealD({15, 13, 10});
-            helpme::Matrix<double> refEvalsImagD(3, 1);
-            auto eigensystemD = mat.diagonalize(helpme::Matrix<double>::SortOrder::Descending);
-            REQUIRE(refEvalsRealD.almostEquals(std::get<0>(eigensystemD)));
-            REQUIRE(refEvalsImagD.almostEquals(std::get<1>(eigensystemD)));
-            REQUIRE(refEvecsD.almostEquals(std::get<2>(eigensystemD)));
+            helpme::Matrix<double> refEvecs({{0.3048963871145365, 0.8972939231558096, -0.31922062682752606},
+                                             {0.5322240637462533, 0.1174283765806552, 0.8384200154713962},
+                                             {0.7897947449140992, -0.42552813284351465, -0.4417579303926363}});
+            helpme::Matrix<double> refEvals({18.08155081781946, 11.787503988646652, 8.1309451935339});
+            auto eigensystem = mat.diagonalize(helpme::Matrix<double>::SortOrder::Descending);
+            REQUIRE(refEvals.almostEquals(std::get<0>(eigensystem)));
+            REQUIRE(refEvecs.almostEquals(std::get<1>(eigensystem)));
+        }
+        SECTION("Ascending order ") {
+            helpme::Matrix<double> refEvecs({{-0.31922062682752606, 0.8972939231558096, 0.3048963871145365},
+                                             {0.8384200154713962, 0.1174283765806552, 0.5322240637462533},
+                                             {-0.4417579303926363, -0.42552813284351465, 0.7897947449140992}});
+            helpme::Matrix<double> refEvals({8.1309451935339, 11.787503988646652, 18.08155081781946});
+            auto eigensystem = mat.diagonalize(helpme::Matrix<double>::SortOrder::Ascending);
+            REQUIRE(refEvals.almostEquals(std::get<0>(eigensystem)));
+            REQUIRE(refEvecs.almostEquals(std::get<1>(eigensystem)));
         }
     }
 }


### PR DESCRIPTION
The early version was designed to wrap BLAS and LAPACK for matrix diagonalization and multiplication.  Those aspects have not proven to be performance bottlenecks so far, so it's best to remove the dependencies and roll a simple version.