### PR TITLE
Fix build for g++-7

### DIFF
--- a/src/matrix.h
+++ b/src/matrix.h
@@ -9,6 +9,7 @@
 #ifndef _HELPME_MATRIX_H_
 #define _HELPME_MATRIX_H_
 
+#include <functional>
 #include <algorithm>
 #include <complex>
 #include <fstream>


### PR DESCRIPTION
For users of g++-7, `<functional>` should be included explicitly to prevent errors like:

``
In file included from /home/bas/temp/git/andysim-helpme-copy/test/unittests/unittest-splines.cpp:12:0:
/home/bas/temp/git/andysim-helpme-copy/src/matrix.h:346:49: error: ‘function’ in namespace ‘std’ does not name a template type
     void applyOperationToEachElement(const std::function<void(Real&)>& function) {
                                                 ^~~~~~~~
``