### PR TITLE
Disable MPI support in LGTM build

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -2,9 +2,6 @@ path_classifiers:
   test:
     - "test/*.cpp"
     - "test/unittests/*.cpp"
-  docs:
-    - README.md
-    - LICENSE
 extraction:
   cpp:
     prepare:
@@ -14,15 +11,10 @@ extraction:
         - libfftw3-dev
         - gfortran
     after_prepare:    # Customizable step used by all languages.
-      - mkdir -p $LGTM_WORKSPACE/latest-gcc-symlinks
-      - ln -s /usr/bin/g++-6 $LGTM_WORKSPACE/latest-gcc-symlinks/g++
-      - ln -s /usr/bin/gcc-6 $LGTM_WORKSPACE/latest-gcc-symlinks/gcc
-      - export PATH=$LGTM_WORKSPACE/latest-gcc-symlinks:$PATH
-      - export GNU_MAKE=make
       - export GIT=true
     configure:    # Customizable step used only by C/C++ extraction.
       command:
-        - cmake -Bbuild -H.
+        - cmake -Bbuild -DENABLE_MPI=Off -H.
     index:    # Customizable step used by all languages.
       build_command:
         - cd build


### PR DESCRIPTION
This disabled MPI support for the LGTM.com build, because the build process fails on Ubuntu Bionic:

```
[2018-10-26 05:18:45] [build] In file included from /opt/src/python/../src/helpme.h:39:0,
[2018-10-26 05:18:45] [build]                  from /opt/src/python/pywrappers.cc:9:
[2018-10-26 05:18:45] [build] /opt/src/python/../src/mpi_wrapper.h:12:10: fatal error: mpi.h: No such file or directory
[2018-10-26 05:18:45] [build]  #include <mpi.h>
[2018-10-26 05:18:45] [build]           ^~~~~~~
```

I get the same error when trying to build your code locally. I've also done some general simplifications and removed some of the 'documentation' files: these are not source code files so won't get scanned by LGTM anyway.

Once we have the C/C++ build working it's easier to experiment with changing the build script in a pull request: the automated code review PR integration will simply tell you whether a change to `lgtm.yml` is good or not. Hope this helps!