### PR TITLE
Fix lgtm.yml: call `make` explicitly

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -18,4 +18,4 @@ extraction:
     index:    # Customizable step used by all languages.
       build_command:
         - cd build
-        - $GNU_MAKE -j2 -s 
+        - make -j2


### PR DESCRIPTION
Apologies — my previous `lgtm.yml` file referred to a non-existing variable

(We're currently building functionality to make it easier to test and debug builds with `lgtm.yml`. That should make our lives a lot easier!)