### PR TITLE
Add namespace to defines and clean FFTW memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ helPME.creator
 helPME.creator.user
 helPME.files
 helPME.includes
+helPME.cflags
+helPME.cxxflags

--- a/src/gamma.h
+++ b/src/gamma.h
@@ -19,9 +19,9 @@
 
 namespace helpme {
 
-#define SQRTTWO std::sqrt(static_cast<Real>(2))
-#define SQRTPI static_cast<Real>(1.77245385090551602729816748334114518279754945612238712821381L)
-#define PI static_cast<Real>(3.14159265358979323846264338327950288419716939937510582097494L)
+#define HELPME_SQRTTWO std::sqrt(static_cast<Real>(2))
+#define HELPME_SQRTPI static_cast<Real>(1.77245385090551602729816748334114518279754945612238712821381L)
+#define HELPME_PI static_cast<Real>(3.14159265358979323846264338327950288419716939937510582097494L)
 
 /*!
  * Compute upper incomplete gamma functions for positive half-integral s values using the recursion
@@ -57,13 +57,13 @@ struct incompleteGammaRecursion<Real, 2, true> {
 /// Specific value of incomplete gamma function.
 template <typename Real>
 struct incompleteGammaRecursion<Real, 1, false> {
-    static Real compute(Real x) { return SQRTPI * erfc(std::sqrt(x)); }
+    static Real compute(Real x) { return HELPME_SQRTPI * erfc(std::sqrt(x)); }
 };
 
 /// Specific value of incomplete gamma function.
 template <typename Real>
 struct incompleteGammaRecursion<Real, 1, true> {
-    static Real compute(Real x) { return SQRTPI * erfc(std::sqrt(x)); }
+    static Real compute(Real x) { return HELPME_SQRTPI * erfc(std::sqrt(x)); }
 };
 
 /// Specific value of incomplete gamma function.
@@ -269,13 +269,13 @@ struct gammaRecursion<Real, 0, false> {
 /// Specific value of the Gamma function.
 template <typename Real>
 struct gammaRecursion<Real, 1, true> {
-    static constexpr Real value = SQRTPI;
+    static constexpr Real value = HELPME_SQRTPI;
 };
 
 /// Specific value of the Gamma function.
 template <typename Real>
 struct gammaRecursion<Real, 1, false> {
-    static constexpr Real value = SQRTPI;
+    static constexpr Real value = HELPME_SQRTPI;
 };
 
 /// Specific value of the Gamma function.
@@ -379,7 +379,7 @@ struct gammaComputer {
 template <typename Real>
 Real nonTemplateGammaComputer(int twoS) {
     if (twoS == 1) {
-        return SQRTPI;
+        return HELPME_SQRTPI;
     } else if (twoS == 2) {
         return 1;
     } else if (twoS <= 0 && twoS % 2 == 0) {


### PR DESCRIPTION
Some predefined constants were given a generic enough name that they could possibly interfere with host code definitions; to fix this they have been prepended by the faux namespace `HELPME_`.  The FFTW wrapper failed to clear the memory used by the plans created, which could accumulate to quite a large size.  To fix this, the destructor now calls the appropriate FFTW method to clear the memory and a swap algorithm is used to guarantee only one free is called for each allocated plan.  The global `fftw_cleanup()` method is not called yet, but this should be less important; if people need it, a `finalize()` like method could be created, but I'm not entirely sure if it's safe to call this in the case that there are multiple active instances (_e.g._ if dispersion and electrostatics are simultaneously handled by two coexisting objects).