### PR TITLE
Fix dipole implementation, add tests

### DIFF
--- a/single_include/helpme_standalone.h
+++ b/single_include/helpme_standalone.h
@@ -2739,10 +2739,10 @@ class PMEInstance {
         if (angMomIterator_.size() >= expectedNTerms) return;
 
         angMomIterator_.resize(expectedNTerms);
-        for (short l = 0, count = 0; l <= L; ++l) {
-            for (short lz = 0; lz <= l; ++lz) {
-                for (short ly = 0; ly <= l - lz; ++ly) {
-                    short lx = l - ly - lz;
+        for (int l = 0, count = 0; l <= L; ++l) {
+            for (int lz = 0; lz <= l; ++lz) {
+                for (int ly = 0; ly <= l - lz; ++ly) {
+                    int lx = l - ly - lz;
                     angMomIterator_[count] = {{static_cast<short>(lx), static_cast<short>(ly), static_cast<short>(lz)}};
                     ++count;
                 }
@@ -5011,13 +5011,13 @@ class PMEInstance {
 
     /*!
      * \brief Computes the full electrostatic potential at atomic sites due to point charges located at those same
-     * sites. The site located at each probe location is neglected, to avoid the resulting singularity \param charges
-     * the list of point charges (in e) associated with each particle. \param coordinates the cartesian coordinates,
-     * ordered in memory as {x1,y1,z1,x2,y2,z2,....xN,yN,zN}. \param potential the array holding the potential.  This is
-     * a matrix of dimensions  nAtoms x 1 \param sphericalCutoff the cutoff (in A) applied to the real space summations,
-     * which must be no more than half of the box dimensions
+     * sites. The site located at each probe location is neglected, to avoid the resulting singularity.
+     * \param charges * the list of point charges (in e) associated with each particle.
+     * \param coordinates the cartesian coordinates, ordered in memory as {x1,y1,z1,x2,y2,z2,....xN,yN,zN}.
+     * \param potential the array holding the potential.  This is * a matrix of dimensions  nAtoms x 1.
+     * \param sphericalCutoff the cutoff (in A) applied to the real space summations,
+     * which must be no more than half of the box dimensions.
      */
-
     void computePAtAtomicSites(const RealMat &charges, const RealMat &coordinates, RealMat &potential,
                                Real sphericalCutoff) {
         sanityChecks(0, charges, coordinates);
@@ -5107,7 +5107,6 @@ class PMEInstance {
      * information about ordering of derivative components. N.B. this array is incremented with the potential, not
      * assigned, so take care to zero it first if only the current results are desired.
      */
-
     void computePRec(int parameterAngMom, const RealMat &parameters, const RealMat &coordinates,
                      const RealMat &gridPoints, int derivativeLevel, RealMat &potential) {
         bool onlyOneShellForInput = parameterAngMom < 0;

--- a/src/helpme.h
+++ b/src/helpme.h
@@ -516,9 +516,11 @@ class PMEInstance {
      * \param splineB the BSpline object for the B direction.
      * \param splineC the BSpline object for the C direction.
      * \param phiPtr a scratch array of length nForceComponents, to store the fractional potential.
-     * \param parameters the list of parameters associated with each atom (charges, C6 coefficients, multipoles,
-     * etc...). For a parameter with angular momentum L, a matrix of dimension nAtoms x nL is expected, where nL =
-     * (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
+     * \param fracParameters the list of parameters associated with the current atom, in
+     * the scaled fraction coordinate basis (charges, C6 coefficients,
+     * multipoles, etc...). For a parameter with angular momentum L, a matrix
+     * of dimension nAtoms x nL is expected, where
+     * nL = (L+1)*(L+2)*(L+3)/6 and the fast running index nL has the ordering
      *
      * 0 X Y Z XX XY YY XZ YZ ZZ XXX XXY XYY YYY XXZ XYZ YYZ XZZ YZZ ZZZ ...
      *
@@ -533,13 +535,13 @@ class PMEInstance {
      */
     void probeGridImpl(const int &atom, const Real *potentialGrid, const int &nComponents, const int &nForceComponents,
                        const Spline &splineA, const Spline &splineB, const Spline &splineC, Real *phiPtr,
-                       const RealMat &parameters, Real *forces) {
+                       const Real *fracParameters, Real *forces) {
         std::fill(phiPtr, phiPtr + nForceComponents, 0);
         probeGridImpl(potentialGrid, nForceComponents, splineA, splineB, splineC, phiPtr);
 
         Real fracForce[3] = {0, 0, 0};
         for (int component = 0; component < nComponents; ++component) {
-            Real param = parameters(atom, component);
+            Real param = fracParameters[component];
             const auto &quanta = angMomIterator_[component];
             short lx = quanta[0];
             short ly = quanta[1];
@@ -1367,6 +1369,14 @@ class PMEInstance {
         Real *realGrid = reinterpret_cast<Real *>(workSpace1_.data());
         updateAngMomIterator(parameterAngMom);
 
+        // We need to figure out whether the incoming parameters need to be transformed to scaled fractional
+        // coordinates or not, which is only needed for angular momentum higher than zero.
+        RealMat tempParams;
+        if (parameterAngMom) {
+            tempParams = cartesianTransform(parameterAngMom, false, scaledRecVecs_.transpose(), parameters);
+        }
+        const auto &fractionalParameters = parameterAngMom ? tempParams : parameters;
+
         int nComponents = nCartesian(parameterAngMom);
         size_t numBA = (size_t)myGridDimensionB_ * myGridDimensionA_;
 #pragma omp parallel num_threads(nThreads_)
@@ -1385,7 +1395,8 @@ class PMEInstance {
                 const auto &splineA = cacheEntry.aSpline;
                 const auto &splineB = cacheEntry.bSpline;
                 const auto &splineC = cacheEntry.cSpline;
-                spreadParametersImpl(atom, realGrid, nComponents, splineA, splineB, splineC, parameters, threadID);
+                spreadParametersImpl(atom, realGrid, nComponents, splineA, splineB, splineC, fractionalParameters,
+                                     threadID);
             }
         }
         return realGrid;
@@ -2186,8 +2197,10 @@ class PMEInstance {
      *              Lx  = L - Ly - Lz
      * \endcode
      * \param forces a Nx3 matrix of the forces, ordered in memory as {Fx1,Fy1,Fz1,Fx2,Fy2,Fz2,....FxN,FyN,FzN}.
+     * \param virial pointer to the virial vector if needed
      */
-    void probeGrid(const Real *potentialGrid, int parameterAngMom, const RealMat &parameters, RealMat &forces) {
+    void probeGrid(const Real *potentialGrid, int parameterAngMom, const RealMat &parameters, RealMat &forces,
+                   Real *virial = nullptr) {
         updateAngMomIterator(parameterAngMom + 1);
         int nComponents = nCartesian(parameterAngMom);
         int nForceComponents = nCartesian(parameterAngMom + 1);
@@ -2197,6 +2210,17 @@ class PMEInstance {
         size_t rowSize = std::ceil(nForceComponents / cacheLineSizeInReals_) * cacheLineSizeInReals_;
         if (fractionalPhis_.nRows() != nThreads_ || fractionalPhis_.nCols() != rowSize) {
             fractionalPhis_ = RealMat(nThreads_, rowSize);
+        }
+        RealMat fractionalParams;
+        Real cartPhi[3];
+        if (parameterAngMom) {
+            fractionalParams = cartesianTransform(parameterAngMom, false, scaledRecVecs_.transpose(), parameters);
+            if (virial) {
+                if (parameterAngMom > 1) {
+                    // The structure factor derivatives below are only implemented up to dipoles for now
+                    throw std::runtime_error("Only multipoles up to L=1 are supported if the virial is requested");
+                }
+            }
         }
         size_t nAtoms = std::accumulate(numAtomsPerThread_.begin(), numAtomsPerThread_.end(), 0);
 #pragma omp parallel num_threads(nThreads_)
@@ -2216,7 +2240,20 @@ class PMEInstance {
                 if (parameterAngMom) {
                     Real *myScratch = fractionalPhis_[threadID % nThreads_];
                     probeGridImpl(absAtom, potentialGrid, nComponents, nForceComponents, splineA, splineB, splineC,
-                                  myScratch, parameters, forces[absAtom]);
+                                  myScratch, fractionalParams[absAtom], forces[absAtom]);
+                    // Add extra virial terms coming from the derivative of the structure factor.
+                    // See eq. 2.16 of https://doi.org/10.1063/1.1630791 for details
+                    if (virial) {
+                        // Get the potential in the Cartesian basis
+                        matrixVectorProduct(scaledRecVecs_, &myScratch[1], &cartPhi[0]);
+                        const Real *parm = parameters[absAtom];
+                        virial[0] += cartPhi[0] * parm[1];
+                        virial[1] += 0.5f * (cartPhi[0] * parm[2] + cartPhi[1] * parm[1]);
+                        virial[2] += cartPhi[1] * parm[2];
+                        virial[3] += 0.5f * (cartPhi[0] * parm[3] + cartPhi[2] * parm[1]);
+                        virial[4] += 0.5f * (cartPhi[1] * parm[3] + cartPhi[2] * parm[2]);
+                        virial[5] += cartPhi[2] * parm[3];
+                    }
                 } else {
                     probeGridImpl(potentialGrid, splineA, splineB, splineC, paramPtr[absAtom], forces[absAtom]);
                 }
@@ -2276,7 +2313,7 @@ class PMEInstance {
      */
     Real computeEDir(const Matrix<short> &pairList, int parameterAngMom, const RealMat &parameters,
                      const RealMat &coordinates) {
-        if (parameterAngMom) throw std::runtime_error("Multipole self terms have not been coded yet.");
+        if (parameterAngMom) throw std::runtime_error("Multipole direct terms have not been coded yet.");
         sanityChecks(parameterAngMom, parameters, coordinates);
 
         Real energy = 0;
@@ -2672,7 +2709,7 @@ class PMEInstance {
         std::fill(workSpace1_.begin(), workSpace1_.end(), 0);
         updateAngMomIterator(parameterAngMom);
         auto fractionalParameters =
-            cartesianTransform(parameterAngMom, onlyOneShellForInput, scaledRecVecs_, parameters);
+            cartesianTransform(parameterAngMom, onlyOneShellForInput, scaledRecVecs_.transpose(), parameters);
         int nComponents = nCartesian(parameterAngMom) - cartesianOffset;
         size_t nAtoms = coordinates.nRows();
         for (size_t atom = 0; atom < nAtoms; ++atom) {
@@ -2728,6 +2765,7 @@ class PMEInstance {
         }
 
         auto fracPotential = potential.clone();
+        fracPotential.setZero();
         cartesianOffset = onlyOneShellForOutput ? nCartesian(derivativeLevel - 1) : 0;
         int nPotentialComponents = nCartesian(derivativeLevel) - cartesianOffset;
         size_t nPoints = gridPoints.nRows();
@@ -2786,6 +2824,7 @@ class PMEInstance {
      */
     Real computeERec(int parameterAngMom, const RealMat &parameters, const RealMat &coordinates) {
         sanityChecks(parameterAngMom, parameters, coordinates);
+
         filterAtomsAndBuildSplineCache(parameterAngMom, coordinates);
         auto realGrid = spreadParameters(parameterAngMom, parameters);
         Real energy;
@@ -2886,7 +2925,7 @@ class PMEInstance {
             auto gridAddress = forwardTransform(realGrid);
             energy = convolveEV(gridAddress, virial);
             auto potentialGrid = inverseTransform(gridAddress);
-            probeGrid(potentialGrid, parameterAngMom, parameters, forces);
+            probeGrid(potentialGrid, parameterAngMom, parameters, forces, virial[0]);
         } else if (algorithmType_ == AlgorithmType::CompressedPME) {
             auto gridAddress = compressedForwardTransform(realGrid);
             Real *convolvedGrid;

--- a/src/matrix.h
+++ b/src/matrix.h
@@ -417,6 +417,17 @@ class Matrix {
     Matrix operator*(const Matrix& other) const { return this->multiply(other); }
 
     /*!
+     * \brief operator * scale a copy of this matrix by a constant, leaving the orignal untouched.
+     * \param scaleFac the scale factor to apply.
+     * \return the scaled version of this matrix.
+     */
+    Matrix operator*(Real scaleFac) const {
+        auto scaled = this->clone();
+        scaled.applyOperationToEachElement([&](Real& element) { element *= scaleFac; });
+        return scaled;
+    }
+
+    /*!
      * \brief increment this matrix with another, returning a new matrix containing the sum.
      * \param other the right hand side of the matrix sum.
      * \return the sum of this matrix and the matrix other.

--- a/test/unittests/CMakeLists.txt
+++ b/test/unittests/CMakeLists.txt
@@ -1,7 +1,10 @@
 # Add any new tests to this list or the one below!
 set( SOURCES_UNITTESTS_TESTS
     unittest-cartesiantransform.cpp
+    unittest-cdq-field-findif.cpp
     unittest-coulombkappasweep.cpp
+    unittest-d-field-kappasweep.cpp
+    unittest-dipolereference.cpp
     unittest-dispersionkappasweep.cpp
     unittest-fft.cpp
     unittest-fletcher.cpp

--- a/test/unittests/unittest-cdq-field-findif.cpp
+++ b/test/unittests/unittest-cdq-field-findif.cpp
@@ -1,0 +1,100 @@
+// BEGINLICENSE
+//
+// This file is part of helPME, which is distributed under the BSD 3-clause license,
+// as described in the LICENSE file in the top level directory of this project.
+//
+// Author: Andrew C. Simmonett
+//
+// ENDLICENSE
+
+#include "catch.hpp"
+
+#include <map>
+
+#include "helpme.h"
+#include <iomanip>
+
+TEST_CASE("check field by finite differences.") {
+    // N.B. This test only passes for cubic test cases right now.  It's possible
+    // the discrepancy is in the h0 term; more investigation needed!
+    helpme::Matrix<double> coords(
+        {{2.0, 2.0, 2.0}, {2.5, 2.0, 3.0}, {1.5, 2.0, 3.0}, {0.0, 0.0, 0.0}, {0.5, 0.0, 1.0}, {-0.5, 0.0, 1.0}});
+    helpme::Matrix<double> params({{-0.5196600000, 0.0000000000, 0.0000000000, 0.0755612194, 0.0484968397, 0.0000000000,
+                                    -0.0534600659, 0.0000000000, 0.0000000000, 0.0049632262},
+                                   {0.2598300000, 0.0320316208, 0.0000000000, 0.0184043956, -0.0002797814, 0.0000000000,
+                                    -0.0137319752, 0.0181894766, 0.0000000000, 0.0140117566},
+                                   {0.2598300000, -0.0320316208, 0.0000000000, 0.0184043956, -0.0002797814,
+                                    0.0000000000, -0.0137319752, -0.0181894766, 0.0000000000, 0.0140117566},
+                                   {-0.5196600000, 0.0000000000, 0.0000000000, 0.0755612194, 0.0484968397, 0.0000000000,
+                                    -0.0534600659, 0.0000000000, 0.0000000000, 0.0049632262},
+                                   {0.2598300000, 0.0320316208, 0.0000000000, 0.0184043956, -0.0002797814, 0.0000000000,
+                                    -0.0137319752, 0.0181894766, 0.0000000000, 0.0140117566},
+                                   {0.2598300000, -0.0320316208, 0.0000000000, 0.0184043956, -0.0002797814,
+                                    0.0000000000, -0.0137319752, -0.0181894766, 0.0000000000, 0.0140117566}});
+    double scaleFactor = 332.0637128;
+    double kappa = 0.4;
+    int gridPts = 64;
+
+    helpme::PMEInstance<double> pme;
+    pme.setup(1, kappa, 8, gridPts, gridPts, gridPts, scaleFactor, 1);
+    pme.setLatticeVectors(25, 25, 25, 90, 90, 90, helpme::PMEInstance<double>::LatticeType::XAligned);
+    helpme::Matrix<double> potential_an(6, 10);
+    helpme::Matrix<double> potentialtmp(6, 1);
+    double mutot[3] = {0, 0, 0};
+    for (int atom = 0; atom < 6; ++atom) {
+        mutot[0] += params[atom][1];
+        mutot[1] += params[atom][2];
+        mutot[2] += params[atom][3];
+    }
+    const double myPI = std::acos(-1.0);
+    const double mySQRTPI = std::sqrt(myPI);
+
+    pme.computePRec(2, params, coords, coords, 2, potential_an);
+
+    double V = pme.cellVolume();
+    double slfprefac = -scaleFactor * 4 * kappa * kappa * kappa / (3 * mySQRTPI);
+    double h0prefac = scaleFactor * 4 * myPI / (3 * V);
+
+    const double DELTA = 0.00001;
+    const double TOL = 1e-8;
+    for (int atom = 0; atom < 6; ++atom) {
+        double *pC = coords[atom];
+        for (int xyz = 0; xyz < 3; ++xyz) {
+            // Numerically differentiate the potential w.r.t. geometry to get the field
+            // Plus 1
+            pC[xyz] += DELTA;
+            potentialtmp.setZero();
+            pme.computePRec(2, params, coords, coords, 0, potentialtmp);
+            double PrecP1 = potentialtmp[atom][0];
+            pC[xyz] -= DELTA;
+            // Minus 1
+            pC[xyz] -= DELTA;
+            potentialtmp.setZero();
+            pme.computePRec(2, params, coords, coords, 0, potentialtmp);
+            double PrecM1 = potentialtmp[atom][0];
+            pC[xyz] += DELTA;
+            // Plus 2
+            pC[xyz] += 2 * DELTA;
+            potentialtmp.setZero();
+            pme.computePRec(2, params, coords, coords, 0, potentialtmp);
+            double PrecP2 = potentialtmp[atom][0];
+            pC[xyz] -= 2 * DELTA;
+            // Minus 2
+            pC[xyz] -= 2 * DELTA;
+            potentialtmp.setZero();
+            pme.computePRec(2, params, coords, coords, 0, potentialtmp);
+            double PrecM2 = potentialtmp[atom][0];
+            pC[xyz] += 2 * DELTA;
+
+            double field_fd = (PrecM2 + 8 * PrecP1 - 8 * PrecM1 - PrecP2) / (12 * DELTA);
+
+            // We need to add some extra terms, per eqs. 31 and 32 of https://doi.org/10.1063/1.481216
+            double mu = params[atom][xyz + 1];
+            double h0term = h0prefac * mu;
+            double slfterm = slfprefac * mu;
+            double field_an = potential_an[atom][xyz + 1] + slfterm + h0term;
+            // std::cout << field_fd - field_an << std::endl;
+            REQUIRE(field_an == Approx(field_fd).margin(TOL));
+        }
+    }
+}

--- a/test/unittests/unittest-d-field-kappasweep.cpp
+++ b/test/unittests/unittest-d-field-kappasweep.cpp
@@ -1,0 +1,268 @@
+// BEGINLICENSE
+//
+// This file is part of helPME, which is distributed under the BSD 3-clause license,
+// as described in the LICENSE file in the top level directory of this project.
+//
+// Author: Andrew C. Simmonett
+//
+// ENDLICENSE
+
+#include "catch.hpp"
+
+#include <map>
+
+#include "helpme.h"
+#include <iomanip>
+
+const double DELTAR = 1e-4;
+const double SQRTPI = std::sqrt(std::acos(-1.0));
+const double TOL = 1e-6;
+
+helpme::Matrix<double> computeRealField(double kappa, const helpme::Matrix<double>& coords_an,
+                                        const helpme::Matrix<double>& charges_fd,
+                                        const helpme::Matrix<double>& coords_fd) {
+    REQUIRE(coords_fd.nRows() == 2 * coords_an.nRows());
+    REQUIRE(coords_fd.nRows() == charges_fd.nRows());
+    helpme::Matrix<double> field(coords_an.nRows(), 4);
+    double kappa2 = kappa * kappa;
+    for (int an = 0; an < coords_an.nRows(); ++an) {
+        double V = 0;
+        double Ex = 0;
+        double Ey = 0;
+        double Ez = 0;
+        for (int fd = 0; fd < coords_fd.nRows(); ++fd) {
+            auto deltaR = coords_fd.row(fd) - coords_an.row(an);
+            double R2 = deltaR.dot(deltaR);
+            double R = std::sqrt(R2);
+            if (R > 1e-2) {
+                double prefac = (2 * kappa * R * std::exp(-kappa2 * R2) / SQRTPI + std::erfc(kappa * R)) / (R * R2);
+                double q = charges_fd[0][fd];
+                V += q * std::erfc(kappa * R) / R;
+                Ex += q * deltaR[0][0] * prefac;
+                Ey += q * deltaR[0][1] * prefac;
+                Ez += q * deltaR[0][2] * prefac;
+            }
+        }
+        field[an][0] = V;
+        field[an][1] = Ex;
+        field[an][2] = Ey;
+        field[an][3] = Ez;
+    }
+    return field;
+}
+
+TEST_CASE("dipole kappa sweep.") {
+    helpme::Matrix<double> coords_an({{2.0, 2.5, 3.0}, {0.0, 0.0, 0.0}});
+    const auto& crd = coords_an;
+    helpme::Matrix<double> potential_an(2, 4);
+    helpme::Matrix<double> potential_fd(2, 4);
+    helpme::Matrix<double> coords_fd({{crd[0][0], crd[0][1], crd[0][2] + DELTAR},
+                                      {crd[1][0], crd[1][1], crd[1][2] + DELTAR},
+                                      {crd[0][0], crd[0][1], crd[0][2] - DELTAR},
+                                      {crd[1][0], crd[1][1], crd[1][2] - DELTAR}});
+    double mu1_z = 1.1;
+    double mu2_z = 1.4;
+    double q1_z = mu1_z / (2 * DELTAR);
+    double q2_z = mu2_z / (2 * DELTAR);
+    helpme::Matrix<double> params_an({{0.0, 0.0, 0.0, mu1_z}, {0.0, 0.0, 0.0, mu2_z}});
+    helpme::Matrix<double> params_fd({q1_z, q2_z, -q1_z, -q2_z});
+    double scaleFactor = 332.0637128;
+    // Listing of interacing pairs in the finite difference model
+    helpme::Matrix<short> pairList{{0, 1}, {0, 3}, {1, 2}, {2, 3}};
+
+    SECTION("reciprocal space findif vs analytical") {
+        // Check that the finite difference approximation to the dipole is correct
+        int gridPts = 64;
+        double kappa = 0.4;
+        helpme::PMEInstance<double> pme;
+        pme.setup(1, kappa, 8, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme.setLatticeVectors(22, 25, 27, 80, 90, 100, helpme::PMEInstance<double>::LatticeType::XAligned);
+        pme.computePRec(0, params_fd, coords_fd, coords_an, 1, potential_fd);
+        pme.computePRec(1, params_an, coords_an, coords_an, 1, potential_an);
+        REQUIRE(potential_fd.almostEquals(potential_an, TOL));
+    }
+
+    SECTION("check invariance of potential and field w.r.t. kappa") {
+        double gridPts = 128;
+        auto potential3 = computeRealField(0.3, coords_an, params_fd, coords_fd) * scaleFactor;
+        helpme::PMEInstance<double> pme3;
+        auto selfPrefac3 = -scaleFactor * 4 * std::pow(0.3, 3) / (3 * SQRTPI);
+        potential3 += params_an * selfPrefac3;
+        pme3.setup(1, 0.3, 8, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme3.setLatticeVectors(35, 35, 35, 85, 90, 95, helpme::PMEInstance<double>::LatticeType::XAligned);
+        pme3.computePRec(1, params_an, coords_an, coords_an, 1, potential3);
+
+        auto potential4 = computeRealField(0.4, coords_an, params_fd, coords_fd) * scaleFactor;
+        helpme::PMEInstance<double> pme4;
+        auto selfPrefac4 = -scaleFactor * 4 * std::pow(0.4, 3) / (3 * SQRTPI);
+        potential4 += params_an * selfPrefac4;
+        pme4.setup(1, 0.4, 9, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme4.setLatticeVectors(35, 35, 35, 85, 90, 95, helpme::PMEInstance<double>::LatticeType::XAligned);
+        pme4.computePRec(1, params_an, coords_an, coords_an, 1, potential4);
+        REQUIRE(potential3.almostEquals(potential4, TOL));
+
+        auto potential5 = computeRealField(0.5, coords_an, params_fd, coords_fd) * scaleFactor;
+        helpme::PMEInstance<double> pme5;
+        auto selfPrefac5 = -scaleFactor * 4 * std::pow(0.5, 3) / (3 * SQRTPI);
+        potential5 += params_an * selfPrefac5;
+        pme5.setup(1, 0.5, 10, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme5.setLatticeVectors(35, 35, 35, 85, 90, 95, helpme::PMEInstance<double>::LatticeType::XAligned);
+        pme5.computePRec(1, params_an, coords_an, coords_an, 1, potential5);
+        REQUIRE(potential4.almostEquals(potential5, TOL));
+    }
+
+    SECTION("check invariance of E w.r.t. kappa") {
+        double gridPts = 128;
+        helpme::PMEInstance<double> pme3;
+        pme3.setup(1, 0.3, 8, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme3.setLatticeVectors(35, 35, 35, 85, 90, 95, helpme::PMEInstance<double>::LatticeType::XAligned);
+        auto E3 = pme3.computeEDir(pairList, 0, params_fd, coords_fd);
+        E3 -= scaleFactor * (mu1_z * mu1_z + mu2_z * mu2_z) * 2 * std::pow(0.3, 3) / (3 * SQRTPI);
+        E3 += pme3.computeERec(1, params_an, coords_an);
+
+        helpme::PMEInstance<double> pme4;
+        pme4.setup(1, 0.4, 9, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme4.setLatticeVectors(35, 35, 35, 85, 90, 95, helpme::PMEInstance<double>::LatticeType::XAligned);
+        auto E4 = pme4.computeEDir(pairList, 0, params_fd, coords_fd);
+        E4 -= scaleFactor * (mu1_z * mu1_z + mu2_z * mu2_z) * 2 * std::pow(0.4, 3) / (3 * SQRTPI);
+        E4 += pme4.computeERec(1, params_an, coords_an);
+        REQUIRE(E3 == Approx(E4).margin(TOL));
+
+        helpme::PMEInstance<double> pme5;
+        pme5.setup(1, 0.5, 10, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme5.setLatticeVectors(35, 35, 35, 85, 90, 95, helpme::PMEInstance<double>::LatticeType::XAligned);
+        auto E5 = pme5.computeEDir(pairList, 0, params_fd, coords_fd);
+        E5 -= scaleFactor * (mu1_z * mu1_z + mu2_z * mu2_z) * 2 * std::pow(0.5, 3) / (3 * SQRTPI);
+        E5 += pme5.computeERec(1, params_an, coords_an);
+        REQUIRE(E4 == Approx(E5).margin(TOL));
+    }
+
+    SECTION("check invariance of EF w.r.t. kappa") {
+        double gridPts = 128;
+        helpme::PMEInstance<double> pme3;
+        pme3.setup(1, 0.3, 8, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme3.setLatticeVectors(35, 35, 35, 85, 90, 95, helpme::PMEInstance<double>::LatticeType::XAligned);
+        helpme::Matrix<double> forces3(2, 3), forces3_fd(4, 3);
+        auto E3 = pme3.computeEFDir(pairList, 0, params_fd, coords_fd, forces3_fd);
+        forces3[0][0] = forces3_fd[0][0] + forces3_fd[2][0];
+        forces3[0][1] = forces3_fd[0][1] + forces3_fd[2][1];
+        forces3[0][2] = forces3_fd[0][2] + forces3_fd[2][2];
+        forces3[1][0] = forces3_fd[1][0] + forces3_fd[3][0];
+        forces3[1][1] = forces3_fd[1][1] + forces3_fd[3][1];
+        forces3[1][2] = forces3_fd[1][2] + forces3_fd[3][2];
+        E3 -= scaleFactor * (mu1_z * mu1_z + mu2_z * mu2_z) * 2 * std::pow(0.3, 3) / (3 * SQRTPI);
+        E3 += pme3.computeEFRec(1, params_an, coords_an, forces3);
+
+        helpme::PMEInstance<double> pme4;
+        pme4.setup(1, 0.4, 9, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme4.setLatticeVectors(35, 35, 35, 85, 90, 95, helpme::PMEInstance<double>::LatticeType::XAligned);
+        helpme::Matrix<double> forces4(2, 3), forces4_fd(4, 3);
+        auto E4 = pme4.computeEFDir(pairList, 0, params_fd, coords_fd, forces4_fd);
+        forces4[0][0] = forces4_fd[0][0] + forces4_fd[2][0];
+        forces4[0][1] = forces4_fd[0][1] + forces4_fd[2][1];
+        forces4[0][2] = forces4_fd[0][2] + forces4_fd[2][2];
+        forces4[1][0] = forces4_fd[1][0] + forces4_fd[3][0];
+        forces4[1][1] = forces4_fd[1][1] + forces4_fd[3][1];
+        forces4[1][2] = forces4_fd[1][2] + forces4_fd[3][2];
+        E4 -= scaleFactor * (mu1_z * mu1_z + mu2_z * mu2_z) * 2 * std::pow(0.4, 3) / (3 * SQRTPI);
+        E4 += pme4.computeEFRec(1, params_an, coords_an, forces4);
+        REQUIRE(E3 == Approx(E4).margin(TOL));
+        REQUIRE(forces3.almostEquals(forces4, TOL));
+
+        helpme::PMEInstance<double> pme5;
+        pme5.setup(1, 0.5, 10, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme5.setLatticeVectors(35, 35, 35, 85, 90, 95, helpme::PMEInstance<double>::LatticeType::XAligned);
+        helpme::Matrix<double> forces5(2, 3), forces5_fd(4, 3);
+        auto E5 = pme5.computeEFDir(pairList, 0, params_fd, coords_fd, forces5_fd);
+        forces5[0][0] = forces5_fd[0][0] + forces5_fd[2][0];
+        forces5[0][1] = forces5_fd[0][1] + forces5_fd[2][1];
+        forces5[0][2] = forces5_fd[0][2] + forces5_fd[2][2];
+        forces5[1][0] = forces5_fd[1][0] + forces5_fd[3][0];
+        forces5[1][1] = forces5_fd[1][1] + forces5_fd[3][1];
+        forces5[1][2] = forces5_fd[1][2] + forces5_fd[3][2];
+        E5 -= scaleFactor * (mu1_z * mu1_z + mu2_z * mu2_z) * 2 * std::pow(0.5, 3) / (3 * SQRTPI);
+        E5 += pme5.computeEFRec(1, params_an, coords_an, forces5);
+        REQUIRE(E4 == Approx(E5).margin(TOL));
+        REQUIRE(forces4.almostEquals(forces5, TOL));
+    }
+
+    SECTION("check invariance of EFV w.r.t. kappa") {
+        double gridPts = 128;
+        auto dR = coords_an.row(1) - coords_an.row(0);
+
+        helpme::PMEInstance<double> pme3;
+        pme3.setup(1, 0.3, 8, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme3.setLatticeVectors(35, 35, 35, 85, 90, 95, helpme::PMEInstance<double>::LatticeType::XAligned);
+        helpme::Matrix<double> forces3(2, 3), forces3_fd(4, 3), virial3(6, 1);
+        auto E3 = pme3.computeEFDir(pairList, 0, params_fd, coords_fd, forces3_fd);
+        forces3[0][0] = forces3_fd[0][0] + forces3_fd[2][0];
+        forces3[0][1] = forces3_fd[0][1] + forces3_fd[2][1];
+        forces3[0][2] = forces3_fd[0][2] + forces3_fd[2][2];
+        forces3[1][0] = forces3_fd[1][0] + forces3_fd[3][0];
+        forces3[1][1] = forces3_fd[1][1] + forces3_fd[3][1];
+        forces3[1][2] = forces3_fd[1][2] + forces3_fd[3][2];
+        virial3[0][0] = -dR[0][0] * (forces3_fd[0][0] + forces3_fd[2][0]);
+        virial3[1][0] = -0.5 * (dR[0][0] * (forces3_fd[0][1] + forces3_fd[2][1]) +
+                                dR[0][1] * (forces3_fd[0][0] + forces3_fd[2][0]));
+        virial3[2][0] = -dR[0][1] * (forces3_fd[0][1] + forces3_fd[2][1]);
+        virial3[3][0] = -0.5 * (dR[0][0] * (forces3_fd[0][2] + forces3_fd[2][2]) +
+                                dR[0][2] * (forces3_fd[0][0] + forces3_fd[2][0]));
+        virial3[4][0] = -0.5 * (dR[0][1] * (forces3_fd[0][2] + forces3_fd[2][2]) +
+                                dR[0][2] * (forces3_fd[0][1] + forces3_fd[2][1]));
+        virial3[5][0] = -dR[0][2] * (forces3_fd[0][2] + forces3_fd[2][2]);
+        E3 -= scaleFactor * (mu1_z * mu1_z + mu2_z * mu2_z) * 2 * std::pow(0.3, 3) / (3 * SQRTPI);
+        E3 += pme3.computeEFVRec(1, params_an, coords_an, forces3, virial3);
+
+        helpme::PMEInstance<double> pme4;
+        pme4.setup(1, 0.4, 9, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme4.setLatticeVectors(35, 35, 35, 85, 90, 95, helpme::PMEInstance<double>::LatticeType::XAligned);
+        helpme::Matrix<double> forces4(2, 3), forces4_fd(4, 3), virial4(6, 1);
+        auto E4 = pme4.computeEFDir(pairList, 0, params_fd, coords_fd, forces4_fd);
+        forces4[0][0] = forces4_fd[0][0] + forces4_fd[2][0];
+        forces4[0][1] = forces4_fd[0][1] + forces4_fd[2][1];
+        forces4[0][2] = forces4_fd[0][2] + forces4_fd[2][2];
+        forces4[1][0] = forces4_fd[1][0] + forces4_fd[3][0];
+        forces4[1][1] = forces4_fd[1][1] + forces4_fd[3][1];
+        forces4[1][2] = forces4_fd[1][2] + forces4_fd[3][2];
+        virial4[0][0] = -dR[0][0] * (forces4_fd[0][0] + forces4_fd[2][0]);
+        virial4[1][0] = -0.5 * (dR[0][0] * (forces4_fd[0][1] + forces4_fd[2][1]) +
+                                dR[0][1] * (forces4_fd[0][0] + forces4_fd[2][0]));
+        virial4[2][0] = -dR[0][1] * (forces4_fd[0][1] + forces4_fd[2][1]);
+        virial4[3][0] = -0.5 * (dR[0][0] * (forces4_fd[0][2] + forces4_fd[2][2]) +
+                                dR[0][2] * (forces4_fd[0][0] + forces4_fd[2][0]));
+        virial4[4][0] = -0.5 * (dR[0][1] * (forces4_fd[0][2] + forces4_fd[2][2]) +
+                                dR[0][2] * (forces4_fd[0][1] + forces4_fd[2][1]));
+        virial4[5][0] = -dR[0][2] * (forces4_fd[0][2] + forces4_fd[2][2]);
+        E4 -= scaleFactor * (mu1_z * mu1_z + mu2_z * mu2_z) * 2 * std::pow(0.4, 3) / (3 * SQRTPI);
+        E4 += pme4.computeEFVRec(1, params_an, coords_an, forces4, virial4);
+        REQUIRE(E3 == Approx(E4).margin(TOL));
+        REQUIRE(forces3.almostEquals(forces4, TOL));
+        REQUIRE(virial3.almostEquals(virial4, TOL));
+
+        helpme::PMEInstance<double> pme5;
+        pme5.setup(1, 0.5, 10, gridPts, gridPts, gridPts, scaleFactor, 1);
+        pme5.setLatticeVectors(35, 35, 35, 85, 90, 95, helpme::PMEInstance<double>::LatticeType::XAligned);
+        helpme::Matrix<double> forces5(2, 3), forces5_fd(4, 3), virial5(6, 1);
+        auto E5 = pme5.computeEFDir(pairList, 0, params_fd, coords_fd, forces5_fd);
+        forces5[0][0] = forces5_fd[0][0] + forces5_fd[2][0];
+        forces5[0][1] = forces5_fd[0][1] + forces5_fd[2][1];
+        forces5[0][2] = forces5_fd[0][2] + forces5_fd[2][2];
+        forces5[1][0] = forces5_fd[1][0] + forces5_fd[3][0];
+        forces5[1][1] = forces5_fd[1][1] + forces5_fd[3][1];
+        forces5[1][2] = forces5_fd[1][2] + forces5_fd[3][2];
+        virial5[0][0] = -dR[0][0] * (forces5_fd[0][0] + forces5_fd[2][0]);
+        virial5[1][0] = -0.5 * (dR[0][0] * (forces5_fd[0][1] + forces5_fd[2][1]) +
+                                dR[0][1] * (forces5_fd[0][0] + forces5_fd[2][0]));
+        virial5[2][0] = -dR[0][1] * (forces5_fd[0][1] + forces5_fd[2][1]);
+        virial5[3][0] = -0.5 * (dR[0][0] * (forces5_fd[0][2] + forces5_fd[2][2]) +
+                                dR[0][2] * (forces5_fd[0][0] + forces5_fd[2][0]));
+        virial5[4][0] = -0.5 * (dR[0][1] * (forces5_fd[0][2] + forces5_fd[2][2]) +
+                                dR[0][2] * (forces5_fd[0][1] + forces5_fd[2][1]));
+        virial5[5][0] = -dR[0][2] * (forces5_fd[0][2] + forces5_fd[2][2]);
+        E5 -= scaleFactor * (mu1_z * mu1_z + mu2_z * mu2_z) * 2 * std::pow(0.5, 3) / (3 * SQRTPI);
+        E5 += pme5.computeEFVRec(1, params_an, coords_an, forces5, virial5);
+        REQUIRE(E4 == Approx(E5).margin(TOL));
+        REQUIRE(forces4.almostEquals(forces5, TOL));
+        REQUIRE(virial4.almostEquals(virial5, TOL));
+    }
+}

--- a/test/unittests/unittest-dipolereference.cpp
+++ b/test/unittests/unittest-dipolereference.cpp
@@ -1,0 +1,98 @@
+// BEGINLICENSE
+//
+// This file is part of helPME, which is distributed under the BSD 3-clause license,
+// as described in the LICENSE file in the top level directory of this project.
+//
+// Author: Andrew C. Simmonett
+//
+// ENDLICENSE
+
+#include "catch.hpp"
+
+#include <map>
+
+#include "helpme.h"
+#include <iomanip>
+
+const double TOL = 1e-8;
+
+TEST_CASE("check small systems against reference values.") {
+    // The reference values here are taken from Table 1 of https://doi.org/10.1063/1.481216
+    helpme::Matrix<double> coords({{-0.5, 0.0, 0.0}, {0.5, 0.0, 0.0}});
+
+    int gridPts = 64;
+    double kappa = 0.8;
+    double kappa2 = kappa * kappa;
+    const double myPI = std::acos(-1.0);
+    double expterm = std::exp(-kappa2) / std::sqrt(myPI);
+    double erfcterm = std::erfc(kappa);
+
+    int splineOrder = 8;
+    SECTION("two charges") {
+        helpme::Matrix<double> forces(2, 3);
+        helpme::Matrix<double> potential(2, 4);
+        helpme::Matrix<double> charges({1.0, -1.0});
+        helpme::PMEInstance<double> pme;
+        pme.setup(1, kappa, splineOrder, gridPts, gridPts, gridPts, 1.0, 1);
+        pme.setLatticeVectors(10, 10, 10, 90, 90, 90, helpme::PMEInstance<double>::LatticeType::XAligned);
+
+        // Potential
+        double realPotential = -erfcterm;
+        double selfPotential = -2 * kappa / std::sqrt(myPI);
+        pme.computePRec(0, charges, coords, coords, 1, potential);
+        double recPotential = potential[0][0];
+        REQUIRE(-1.0021255 == Approx(recPotential + realPotential + selfPotential).margin(TOL));
+
+        // Field
+        double realField = 2 * kappa * expterm + erfcterm;
+        double recField = -potential[0][1];
+        REQUIRE(0.9956865 == Approx(recField + realField).margin(TOL));
+
+        // Energy
+        double realEnergy = charges[0][0] * realPotential;
+        double selfEnergy = charges[0][0] * selfPotential;
+        double recEnergy = pme.computeERec(0, charges, coords);
+        REQUIRE(-1.0021255 == Approx(recEnergy + realEnergy + selfEnergy).margin(TOL));
+
+        // Force
+        double efEnergy = pme.computeEFRec(0, charges, coords, forces);
+        double realForce = charges[0][0] * realField;
+        double recForce = forces[0][0];
+        REQUIRE(efEnergy == recEnergy);
+        REQUIRE(0.9956865 == Approx(recForce + realForce).margin(TOL));
+    }
+
+    SECTION("two dipoles") {
+        helpme::Matrix<double> forces(2, 3);
+        helpme::Matrix<double> potential(2, 4);
+        helpme::Matrix<double> dipoles({{0.0, 1.0, 0.0, 0.0}, {0.0, 1.0, 0.0, 0.0}});
+        helpme::PMEInstance<double> pme;
+        pme.setup(1, kappa, splineOrder, gridPts, gridPts, gridPts, 1.0, 1);
+        pme.setLatticeVectors(10, 10, 10, 90, 90, 90, helpme::PMEInstance<double>::LatticeType::XAligned);
+
+        // Potential
+        pme.computePRec(1, dipoles, coords, coords, 1, potential);
+        double realPotential = 2 * kappa * expterm + erfcterm;
+        double recPotential = -potential[0][0];
+        REQUIRE(0.9956865 == Approx(recPotential + realPotential).margin(TOL));
+
+        // Field
+        double realField = -4 * kappa * (1 + kappa2) * expterm - 2 * erfcterm;
+        double recField = potential[0][1];
+        double selfField = -4 * kappa * kappa2 / (3 * std::sqrt(myPI));
+        REQUIRE(-2.0087525 == Approx(realField + selfField + recField).margin(TOL));
+
+        // Energy
+        double realEnergy = dipoles[0][1] * realField;
+        double selfEnergy = dipoles[0][1] * selfField;
+        double recEnergy = pme.computeERec(1, dipoles, coords);
+        REQUIRE(-2.0087525 == Approx(realEnergy + selfEnergy + recEnergy).margin(TOL));
+
+        // Force
+        double efEnergy = pme.computeEFRec(1, dipoles, coords, forces);
+        double realForce = 4 * kappa * (3 + 2 * (kappa2 + kappa2 * kappa2)) * expterm + 6 * erfcterm;
+        double recForce = forces[0][0];
+        REQUIRE(efEnergy == recEnergy);
+        REQUIRE(5.9992460 == Approx(realForce + recForce).margin(TOL));
+    }
+}

--- a/test/unittests/unittest-fullrun-multipoles.cpp
+++ b/test/unittests/unittest-fullrun-multipoles.cpp
@@ -1744,7 +1744,7 @@ TEST_CASE("Full run with a small toy system, comprising two water molecules with
         REQUIRE(fractionalParams.almostEquals(refFractionalParamsD, TOL));
 
         pmeD->filterAtomsAndBuildSplineCache(5, coordsD);
-        auto realGrid = pmeD->spreadParameters(4, fractionalParams);
+        auto realGrid = pmeD->spreadParameters(4, paramsD);
         helpme::Matrix<double> chargeGrid(realGrid, nfftz * nffty, nfftx);
         REQUIRE(refChargeGridD.almostEquals(chargeGrid, TOL));
 
@@ -1759,7 +1759,7 @@ TEST_CASE("Full run with a small toy system, comprising two water molecules with
         helpme::Matrix<double> potentialGrid(realGrid, nfftz * nffty, nfftx);
         REQUIRE(refPotentialGridD.almostEquals(potentialGrid, TOL));
 
-        pmeD->probeGrid(realGrid, 4, fractionalParams, forcesD);
+        pmeD->probeGrid(realGrid, 4, paramsD, forcesD);
         REQUIRE(refForcesD.almostEquals(forcesD, TOL));
         REQUIRE(refRecEnergy == Approx(energy).margin(TOL));
     }
@@ -1779,7 +1779,7 @@ TEST_CASE("Full run with a small toy system, comprising two water molecules with
         REQUIRE(fractionalParams.almostEquals(refFractionalParamsD.cast<float>(), TOL));
 
         pmeF->filterAtomsAndBuildSplineCache(5, coordsD.cast<float>());
-        auto realGrid = pmeF->spreadParameters(4, fractionalParams);
+        auto realGrid = pmeF->spreadParameters(4, paramsD.cast<float>());
         helpme::Matrix<float> chargeGrid(realGrid, nfftz * nffty, nfftx);
         REQUIRE(refChargeGridD.cast<float>().almostEquals(chargeGrid, TOL));
 
@@ -1794,7 +1794,7 @@ TEST_CASE("Full run with a small toy system, comprising two water molecules with
         helpme::Matrix<float> potentialGrid(realGrid, nfftz * nffty, nfftx);
         REQUIRE(refPotentialGridD.cast<float>().almostEquals(potentialGrid, TOL));
 
-        pmeF->probeGrid(realGrid, 4, fractionalParams, forcesF);
+        pmeF->probeGrid(realGrid, 4, paramsD.cast<float>(), forcesF);
         REQUIRE(refForcesD.cast<float>().almostEquals(forcesF, TOL));
         REQUIRE(refRecEnergy == Approx(energy).margin(TOL));
     }

--- a/test/unittests/unittest-matrix.cpp
+++ b/test/unittests/unittest-matrix.cpp
@@ -150,6 +150,13 @@ TEST_CASE("test the matrix class.") {
         REQUIRE(product.almostEquals(L * R));
     }
 
+    SECTION("Scaling ") {
+        helpme::Matrix<double> mat({{3, 4, 2}, {-4, 1, 2}});
+        helpme::Matrix<double> mat2({{6, 8, 4}, {-8, 2, 4}});
+        std::cout << mat * 2.0 << std::endl;
+        REQUIRE(mat2.almostEquals(mat * 2.0));
+    }
+
     SECTION("Dot product ") {
         helpme::Matrix<double> mat1({{3.5, 3, 2}});
         helpme::Matrix<double> mat2({{3, 1.5, 2.1}});

--- a/test/unittests/unittest-matrix.cpp
+++ b/test/unittests/unittest-matrix.cpp
@@ -153,7 +153,6 @@ TEST_CASE("test the matrix class.") {
     SECTION("Scaling ") {
         helpme::Matrix<double> mat({{3, 4, 2}, {-4, 1, 2}});
         helpme::Matrix<double> mat2({{6, 8, 4}, {-8, 2, 4}});
-        std::cout << mat * 2.0 << std::endl;
         REQUIRE(mat2.almostEquals(mat * 2.0));
     }
 


### PR DESCRIPTION
#56 and #57 found some errors in the multipole implementation.  This PR fleshes out the implementation for dipoles (torque terms are not addressed yet, so body-fixed dipoles are currently not supported fully).  Three new tests are added; direct testing against the literature for dipoles, a "kappa sweep" to show invariance of the dipole potential, the energy, and derivatives thereof, with respect to the Ewald screening parameter.  Another new test shows the equivalence of the field and the numerically differentiated potential, but it breaks when a non-cubic unit cells is used, so the implementation of h=0 term may not be correct at this point; the test is fine when only charges and quadrupoles are present.