### PR TITLE
Update README with GHA build status

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -101,6 +101,7 @@ jobs:
     - name: Upload CodeCov
       working-directory: ${{github.workspace}}/build
       run: |
+           ls
            lcov --directory . --capture --output-file coverage.info # capture coverage info
            lcov --remove coverage.info '/usr/*' '*single_include*'  --output-file coverage.info # filter out system
            lcov --list coverage.info #debug info

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<a href="https://travis-ci.org/andysim/helpme"> <img src="https://travis-ci.org/andysim/helpme.svg?branch=master" /></a>
+<a href="https://github.com/andysim/helpme/actions"> <img src="https://github.com/andysim/helpme/actions/workflows/cmake.yml/badge.svg?branch=master" /></a>
 <a href="https://codecov.io/gh/andysim/helpme"> <img src="https://img.shields.io/codecov/c/github/andysim/helpme/master.svg" /></a>
 <a href="https://lgtm.com/projects/g/andysim/helpme/context:cpp"><img alt="Language grade: C/C++" src="https://img.shields.io/lgtm/grade/cpp/g/andysim/helpme.svg?logo=lgtm&logoWidth=18"/></a>
 <a href="https://lgtm.com/projects/g/andysim/helpme/context:python"><img alt="Language grade: Python" src="https://img.shields.io/lgtm/grade/python/g/andysim/helpme.svg?logo=lgtm&logoWidth=18"/></a>


### PR DESCRIPTION
Now Travis is unused for CI, the README points to Github Actions to show the latest build status.