### PR TITLE
Enable building a shared library and add options to turn off testing and Python binding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,13 +156,16 @@ endif()
 # The C++ library is linked explicitly because exception handling on macOS appears to be broken otherwise.
 set(EXTERNAL_LIBRARIES ${BLAS_LIBRARIES} ${FFTW_LIBRARIES} ${cpplib})
 
+option(ENABLE_Python "Enables the building of Python bindings" ON)
+if(ENABLE_Python)
 # Find Python
-set(Python_ADDITIONAL_VERSIONS 3.9 3.8 3.7 3.6)
-find_package(PythonLibsNew 3.6 REQUIRED)
-message(STATUS "${Cyan}Found Python ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}${ColourReset}: ${PYTHON_EXECUTABLE} (found version ${PYTHON_VERSION_STRING})")
-set(Python_ENABLED ON) # For now, we just always assume this is on
-add_subdirectory(external/pybind11)
-add_subdirectory(python)
+    set(Python_ADDITIONAL_VERSIONS 3.9 3.8 3.7 3.6)
+    find_package(PythonLibsNew 3.6 REQUIRED)
+    message(STATUS "${Cyan}Found Python ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}${ColourReset}: ${PYTHON_EXECUTABLE} (found version ${PYTHON_VERSION_STRING})")
+    set(Python_ENABLED ON) # For now, we just always assume this is on
+    add_subdirectory(external/pybind11)
+    add_subdirectory(python)
+endif()
 
 # Documentation
 find_package(Doxygen)
@@ -179,6 +182,8 @@ add_subdirectory(src)
 #
 # Testing
 #
-enable_testing ()
-add_subdirectory (test)
+include(CTest)
+if(BUILD_TESTING)
+    add_subdirectory (test)
+endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,8 @@ include_directories(${FFTW_INCLUDES})
 include_directories(${MKL_INCLUDE_DIR})
 add_library(helpmestatic STATIC ${sources_list})
 target_link_libraries(helpmestatic ${FFTW_LIBRARIES})
+add_library(helpme SHARED ${sources_list})
+target_link_libraries(helpme ${FFTW_LIBRARIES})
 
 if(Fortran_ENABLED AND CMAKE_Fortran_COMPILER_ID MATCHES Intel)
     #Enable call to for_rtl_init_() which is required if using the
@@ -18,7 +20,7 @@ set_target_properties(helpmestatic PROPERTIES OUTPUT_NAME helpme EXPORT_NAME hel
 # Make sure headers are installed
 install(DIRECTORY . DESTINATION include FILES_MATCHING PATTERN "*.h")
 
-install(TARGETS helpmestatic
+install(TARGETS helpmestatic helpme
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)


### PR DESCRIPTION
I am using helpme as a shared library in a Julia project I am working on. If you don't mind, I would like to host the compiled libraries on Julia's centralized binary hosting repository at https://github.com/JuliaBinaryWrappers/. And this request will make it easy for the building system they have, and it does not change the current behavior for CMake except for adding a shared library.